### PR TITLE
Change master target group type from instance to ip

### DIFF
--- a/docs/releases/v1.15.4-1.md
+++ b/docs/releases/v1.15.4-1.md
@@ -1,0 +1,164 @@
+# Release notes
+
+This version contains a patch in the [`aws-kubernetes` terraform module](modules/aws-kubernetes) that fixes a problem with internal master to master communication.
+
+## Master nodes load balancer issue
+
+### Use case
+
+If a master node tries to communicate with other master node using the internal load balancer in front of the master nodes, it's possible to get a timeout if the request is sent to the same node that sent it.
+
+It was detected while creating a new kubeadm token from a master node. The request was triggered from one master nodes, passed through the load balancer and was stuck there.
+The load balancer could not pass the request to the same node the request was created.
+
+It would have worked if the request had been passed to another master node instance. But you can't control that behavior.
+
+### Issue (official) documentation
+
+#### Connections time out for requests from a target to its load balancer
+
+Check whether you have an internal load balancer with targets registered by instance ID. Internal load balancers do not support hairpinning or loopback. When you register targets by instance ID, the source IP addresses of clients are preserved. If an instance is a client of an internal load balancer that it's registered with by instance ID, the connection succeeds only if the request is routed to a different instance. Otherwise, the source and destination IP addresses are the same and the connection times out.
+
+> If an instance must send requests to a load balancer that it's registered with, do one of the following:
+> - Register instances by IP address instead of instance ID. When using Amazon Elastic Container Service, use the awsvpc network mode with your tasks to ensure that target groups require registration by IP address.
+> - Ensure that containers that must communicate are on different container instances.
+> - Use an Internet-facing load balancer.
+
+*source: [https://docs.aws.amazon.com - load-balancer-troubleshooting.html#loopback-timeout](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-troubleshooting.html#loopback-timeout)*
+
+### Change
+
+We opt to change the way master nodes are registered in the target group, moving from `instance` to `ip` target group type.
+
+#### How to deploy it
+
+##### Requirements
+
+Having version 1.15.4 deployed, change the version to 1.15.4-1 in your `Furyfile.yml`, then:
+
+```bash
+$ furyctl install
+```
+
+This command downloads the patch in your `vendor/modules/aws/aws-kubernetes` directory.
+
+
+##### Before deploy
+
+You can check terraform plans before applying the new configuration.
+
+*truncated output*
+```bash
+$ terraform plan --destroy --target module.<YOUR_INSTANCE_OF_AWS_KUBERNETES_MODULE_NAME>.aws_lb_listener.k8s-master
+
+An execution plan has been generated and is shown below.
+Resource actions are indicated with the following symbols:
+  - destroy
+
+Terraform will perform the following actions:
+
+  - module.k8s.aws_lb_listener.k8s-master
+
+
+Plan: 0 to add, 0 to change, 1 to destroy.
+```
+
+The `terraform destroy` command should destroy just one resource.
+
+*truncated output*
+```bash
+$ terraform plan
+
+  ~ module.k8s.aws_lb_listener.k8s-master
+      default_action.0.target_group_arn:  "arn:aws:elasticloadbalancing:eu-west-1:ACCOUNT-ID:targetgroup/fury-demo-k8s-master/tid" => "${aws_lb_target_group.k8s-master.arn}"
+
+-/+ module.k8s.aws_lb_target_group.k8s-master (new resource required)
+      id:                                 "arn:aws:elasticloadbalancing:eu-west-1:ACCOUNT-ID:targetgroup/fury-demo-k8s-master/tid" => <computed> (forces new resource)
+      arn:                                "arn:aws:elasticloadbalancing:eu-west-1:ACCOUNT-ID:targetgroup/fury-demo-k8s-master/tid" => <computed>
+      arn_suffixeses:                         "targetgroup/fury-demo-k8s-master/tid" => <computed>
+      deregistration_delay:               "300" => "300"
+      health_check.#:                     "1" => "1"
+      health_check.0.healthy_threshold:   "2" => "2"
+      health_check.0.interval:            "30" => "30"
+      health_check.0.matcher:             "" => <computed>
+      health_check.0.path:                "" => <computed>
+      health_check.0.port:                "6443" => "6443"
+      health_check.0.protocol:            "TCP" => "TCP"
+      health_check.0.timeout:             "10" => <computed>
+      health_check.0.unhealthy_threshold: "2" => "2"
+      name:                               "fury-demo-k8s-master" => "fury-demo-k8s-master"
+      port:                               "6443" => "6443"
+      protocol:                           "TCP" => "TCP"
+      proxy_protocol_v2:                  "false" => "false"
+      slow_start:                         "0" => "0"
+      stickiness.#:                       "0" => <computed>
+      target_type:                        "instance" => "ip" (forces new resource)
+      vpc_id:                             "vpc-id" => "vpc-id"
+
+-/+ module.k8s.aws_lb_target_group_attachment.k8s-master[0] (new resource required)
+      id:                                 "arn:aws:elasticloadbalancing:eu-west-1:ACCOUNT-ID:targetgroup/fury-demo-k8s-master/tid-aid594200000006" => <computed> (forces new resource)
+      target_group_arn:                   "arn:aws:elasticloadbalancing:eu-west-1:ACCOUNT-ID:targetgroup/fury-demo-k8s-master/tid" => "${aws_lb_target_group.k8s-master.arn}" (forces new resource)
+      target_id:                          "i-0" => "10.100.10.96" (forces new resource)
+
+-/+ module.k8s.aws_lb_target_group_attachment.k8s-master[1] (new resource required)
+      id:                                 "arn:aws:elasticloadbalancing:eu-west-1:ACCOUNT-ID:targetgroup/fury-demo-k8s-master/tid-aid929900000008" => <computed> (forces new resource)
+      target_group_arn:                   "arn:aws:elasticloadbalancing:eu-west-1:ACCOUNT-ID:targetgroup/fury-demo-k8s-master/tid" => "${aws_lb_target_group.k8s-master.arn}" (forces new resource)
+      target_id:                          "i-1" => "10.100.11.26" (forces new resource)
+
+-/+ module.k8s.aws_lb_target_group_attachment.k8s-master[2] (new resource required)
+      id:                                 "arn:aws:elasticloadbalancing:eu-west-1:ACCOUNT-ID:targetgroup/fury-demo-k8s-master/tid-aid223100000004" => <computed> (forces new resource)
+      target_group_arn:                   "arn:aws:elasticloadbalancing:eu-west-1:ACCOUNT-ID:targetgroup/fury-demo-k8s-master/tid" => "${aws_lb_target_group.k8s-master.arn}" (forces new resource)
+      target_id:                          "i-2" => "10.100.12.251" (forces new resource)
+
+-/+ module.k8s.aws_lb_target_group_attachment.k8s-master[3] (new resource required)
+      id:                                 "arn:aws:elasticloadbalancing:eu-west-1:ACCOUNT-ID:targetgroup/fury-demo-k8s-master/tid-aid262500000005" => <computed> (forces new resource)
+      target_group_arn:                   "arn:aws:elasticloadbalancing:eu-west-1:ACCOUNT-ID:targetgroup/fury-demo-k8s-master/tid" => "${aws_lb_target_group.k8s-master.arn}" (forces new resource)
+      target_id:                          "i-3" => "10.100.10.40" (forces new resource)
+
+-/+ module.k8s.aws_lb_target_group_attachment.k8s-master[4] (new resource required)
+      id:                                 "arn:aws:elasticloadbalancing:eu-west-1:ACCOUNT-ID:targetgroup/fury-demo-k8s-master/tid-aid642200000007" => <computed> (forces new resource)
+      target_group_arn:                   "arn:aws:elasticloadbalancing:eu-west-1:ACCOUNT-ID:targetgroup/fury-demo-k8s-master/tid" => "${aws_lb_target_group.k8s-master.arn}" (forces new resource)
+      target_id:                          "i-4" => "10.100.11.191" (forces new resource)
+
+
+Plan: 6 to add, 1 to change, 6 to destroy.
+```
+
+This command was executed in a cluster with 5 master nodes. This is why there are 6 changes. Take care about it with your cluster configuration.
+
+##### Applying it
+
+If everything is fine with the plans, we are ready to go!
+
+```bash
+$ terraform destroy --target module.<YOUR_INSTANCE_OF_AWS_KUBERNETES_MODULE_NAME>.aws_lb_listener.k8s-master
+$ terraform apply -auto-approve
+```
+
+This changes does not causes downtime in the application layer as ingress controller infrastructure stays untouched.
+
+As this change only affects the master internal load balancer, it can occur a downtime in the kubernetes API, this means that you can encounter problems while interacting with the kubernetes API server *(deploying, checks...)*
+
+##### Verify
+
+You can run a simple script to verify the new configuration is working:
+
+```bash
+$ ansible master -b -m shell -a 'kubeadm token create --print-join-command --ttl=30m'
+
+PLAY [Ansible Ad-Hoc] **************************************************************************************************************************************************************************************
+
+TASK [shell] ***********************************************************************************************************************************************************************************************
+changed: [master-3]
+changed: [master-4]
+changed: [master-5]
+changed: [master-2]
+changed: [master-1]
+
+PLAY RECAP *************************************************************************************************************************************************************************************************
+master-1                   : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+master-2                   : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+master-3                   : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+master-4                   : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+master-5                   : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+```

--- a/modules/aws-kubernetes/lb_app_internal.tf
+++ b/modules/aws-kubernetes/lb_app_internal.tf
@@ -54,9 +54,9 @@ resource "aws_lb_listener" "k8s-nodes-https-internal" {
 }
 
 resource "aws_lb_listener_certificate" "internal-http" {
-  count           = "${length(var.kube-lb-internal-additional-domains) == 0 ? 0 : length(var.kube-lb-internal-additional-domains)-1}"
+  count           = "${length(var.kube-lb-internal-additional-domains) == 0 ? 0 : length(var.kube-lb-internal-additional-domains) - 1}"
   listener_arn    = "${aws_lb_listener.k8s-nodes-https-internal.arn}"
-  certificate_arn = "${element(data.aws_acm_certificate.internal.*.arn, count.index+1)}"
+  certificate_arn = "${element(data.aws_acm_certificate.internal.*.arn, count.index + 1)}"
 }
 
 resource "aws_lb_target_group" "k8s-nodes-internal" {

--- a/modules/aws-kubernetes/lb_external.tf
+++ b/modules/aws-kubernetes/lb_external.tf
@@ -62,9 +62,9 @@ resource "aws_lb_listener" "k8s-nodes-https" {
 }
 
 resource "aws_lb_listener_certificate" "main" {
-  count           = "${length(var.kube-lb-external-domains) == 0 ? 0 : length(var.kube-lb-external-domains)-1}"
+  count           = "${length(var.kube-lb-external-domains) == 0 ? 0 : length(var.kube-lb-external-domains) - 1}"
   listener_arn    = "${aws_lb_listener.k8s-nodes-https.arn}"
-  certificate_arn = "${element(data.aws_acm_certificate.main.*.arn, count.index+1)}"
+  certificate_arn = "${element(data.aws_acm_certificate.main.*.arn, count.index + 1)}"
 }
 
 data "aws_acm_certificate" "main" {

--- a/modules/aws-kubernetes/lb_net_internal.tf
+++ b/modules/aws-kubernetes/lb_net_internal.tf
@@ -18,7 +18,7 @@ resource "aws_lb_target_group" "k8s-master" {
   port        = 6443
   protocol    = "TCP"
   vpc_id      = "${data.aws_subnet.public.0.vpc_id}"
-  target_type = "instance"
+  target_type = "ip"
 
   health_check {
     healthy_threshold   = 2
@@ -43,7 +43,7 @@ resource "aws_lb_listener" "k8s-master" {
 resource "aws_lb_target_group_attachment" "k8s-master" {
   count            = "${var.kube-master-count}"
   target_group_arn = "${aws_lb_target_group.k8s-master.arn}"
-  target_id        = "${element(aws_instance.k8s-master.*.id, count.index)}"
+  target_id        = "${element(aws_instance.k8s-master.*.private_ip, count.index)}"
 }
 
 resource "aws_lb_target_group" "internal-ingress" {


### PR DESCRIPTION
Hi!!!

During the development of the auto-join node feature we found an issue with the internal master load balancer.

If a master node tries to communicate with other master node using the internal load balancer in front of the master nodes, it's possible to get a timeout if the request is sent to the same node that sent it.

This error is already listed in the aws documentation site: https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-troubleshooting.html#loopback-timeout : 

> If an instance must send requests to a load balancer that it's registered with, do one of the following:
> - Register instances by IP address instead of instance ID. When using Amazon Elastic Container Service, use the awsvpc network mode with your tasks to ensure that target groups require registration by IP address.
> - Ensure that containers that must communicate are on different container instances.
> - Use an Internet-facing load balancer.

The complete detail is present in the `docs/releases/v1.15.4-1.md` file.

Thanks!