### PR TITLE
Using a unique id to attach internal/external lb to infra nodes

### DIFF
--- a/docs/releases/v1.15.4-3.md
+++ b/docs/releases/v1.15.4-3.md
@@ -1,0 +1,63 @@
+# Release notes
+
+- [Release notes](#release-notes)
+  - [Infra nodes load balancer issue](#infra-nodes-load-balancer-issue)
+    - [Use case](#use-case)
+    - [Issue](#issue)
+    - [Change](#change)
+      - [How to deploy it](#how-to-deploy-it)
+        - [Requirements](#requirements)
+        - [Before deploy](#before-deploy)
+        - [Applying it](#applying-it)
+        - [Verify](#verify)
+
+This version contains a patch in the [`aws-kubernetes` terraform module](modules/aws-kubernetes) that fixes the problem
+having multiple kubernetes cluster in the same VPC.
+
+## Infra nodes load balancer issue
+
+### Use case
+
+Due the the actual resource tags, it's not possible to have more than one cluster in the same VPC deployed with this
+module.
+
+### Issue
+
+Having more than one cluster in the same VPC, the kubernetes terraform module will register every infra node to every
+infrastructure load balancer, with no cluster filter.
+
+### Change
+
+Adding a new tag to the ASG resources and then filtering by it it's enough.
+
+#### How to deploy it
+
+##### Requirements
+
+Having version 1.15.4 deployed, change the version to 1.15.4-3 in your `Furyfile.yml`, then:
+
+```bash
+$ furyctl install
+```
+
+This command downloads the patch in your `vendor/modules/aws/aws-kubernetes` directory.
+
+##### Before deploy
+
+You can check terraform plans before applying the new configuration.
+
+```bash
+$ terraform plan
+```
+
+##### Applying it
+
+If everything is fine with the terraform plan, we are ready to go!
+
+```bash
+$ terraform apply -auto-approve
+```
+
+##### Verify
+
+Check the infrastructure ASG tags looking for the new one named: `KubernetesClusterAndType`.

--- a/modules/aws-kubernetes/kube-worker.tf
+++ b/modules/aws-kubernetes/kube-worker.tf
@@ -43,6 +43,11 @@ resource "aws_autoscaling_group" "main" {
       value               = "${var.name}-${var.env}"
       propagate_at_launch = "true"
     },
+    {
+      key                 = "KubernetesClusterAndType"
+      value               = "${lookup(var.kube-workers[count.index], "kind")}-${var.name}-${var.env}"
+      propagate_at_launch = "true"
+    },
   ]
 
   lifecycle {
@@ -65,11 +70,11 @@ data "aws_instances" "main" {
 data "aws_autoscaling_groups" "infra" {
   filter {
     name   = "key"
-    values = ["Type"]
+    values = ["KubernetesClusterAndType"]
   }
 
   filter {
     name   = "value"
-    values = ["infra"]
+    values = ["infra-${var.name}-${var.env}"]
   }
 }


### PR DESCRIPTION
This will allow to have multiple clusters in the same vpc, ensuring the loadbalancers are attached to the correct infra instances.