### PR TITLE
Add termination policy to every ASG in a kubernetes cluster

### DIFF
--- a/docs/releases/v1.15.4-4.md
+++ b/docs/releases/v1.15.4-4.md
@@ -1,0 +1,63 @@
+# Release notes
+
+- [Release notes](#release-notes)
+  - [Non Master autoscalling group](#non-master-autoscalling-group)
+    - [Use case](#use-case)
+    - [Issue (official) documentation](#issue-official-documentation)
+    - [Change](#change)
+      - [How to deploy it](#how-to-deploy-it)
+        - [Requirements](#requirements)
+        - [Before deploy](#before-deploy)
+        - [Applying it](#applying-it)
+        - [Verify](#verify)
+
+This version contains a patch in the [`aws-kubernetes` terraform module](modules/aws-kubernetes) that fixes a problem
+with the autoscalling group termination policy.
+
+## Non Master autoscalling group
+
+### Use case
+
+During a rollout, when scale back down to the normal capacity, it's expected to destroy the oldest instances.
+
+### Issue (official) documentation
+
+> When you customize the termination policy, if one Availability Zone has more instances than the other Availability Zones that are used by the group, your termination policy is applied to the instances from the imbalanced Availability Zone. If the Availability Zones used by the group are balanced, the termination policy is applied across all of the Availability Zones for the group.
+
+*source:* [https://docs.aws.amazon.com/autoscaling](https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-instance-termination.html)
+
+### Change
+
+Adding a new attribute to the ASG improves the behavior.
+
+#### How to deploy it
+
+##### Requirements
+
+Having version 1.15.4 deployed, change the version to 1.15.4-4 in your `Furyfile.yml`, then:
+
+```bash
+$ furyctl install
+```
+
+This command downloads the patch in your `vendor/modules/aws/aws-kubernetes` directory.
+
+##### Before deploy
+
+You can check terraform plans before applying the new configuration.
+
+```bash
+$ terraform plan
+```
+
+##### Applying it
+
+If everything is fine with the terraform plan, we are ready to go!
+
+```bash
+$ terraform apply -auto-approve
+```
+
+##### Verify
+
+Check the `termination_policies` in every ASG. It should has the `OldestInstance` value.

--- a/modules/aws-kubernetes/kube-worker.tf
+++ b/modules/aws-kubernetes/kube-worker.tf
@@ -26,6 +26,7 @@ resource "aws_autoscaling_group" "main" {
   max_size             = "${lookup(var.kube-workers[count.index], "count")}"
   min_size             = "${lookup(var.kube-workers[count.index], "count")}"
   launch_configuration = "${element(aws_launch_configuration.main.*.name, count.index)}"
+  termination_policies = ["OldestInstance"]
 
   tags = [
     {

--- a/packer/terraform/main.tf
+++ b/packer/terraform/main.tf
@@ -55,7 +55,7 @@ variable "user" {
 }
 
 variable "fury-version" {
-  default = "1.15.4-2"
+  default = "1.15.4-4"
 }
 
 locals {


### PR DESCRIPTION
Hi team

During a cluster operation we encountered with this "issue". Adding the `OldestInstance` mitigates the issue, but during a rollout we have to know how AWS works.

So, having a custom policy:

> When you customize the termination policy, if one Availability Zone has more instances than the other Availability Zones that are used by the group, your termination policy is applied to the instances from the imbalanced Availability Zone. If the Availability Zones used by the group are balanced, the termination policy is applied across all of the Availability Zones for the group. 

source: https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-instance-termination.html

So during a rollout of 2 nodes: we should do the following:

Increase to 4 nodes. Then scale down to 3. Then scale down back to 2. 

If we scale down from 4 to 2 in an ASG with 3azs configured we can see how a "new" instances is destroyed.

Thanks!