### PR TITLE
exponential backoff on join command

### DIFF
--- a/roles/kube-node-common/files/auto-join-node.sh
+++ b/roles/kube-node-common/files/auto-join-node.sh
@@ -2,27 +2,64 @@
 
 source /cloud-init-report-alert.sh
 
-function err_retry() {
-  local exit_code=$1
-  local attempts=$2
-  local sleep_millis=$3
-  shift 3
-  for attempt in `seq 1 $attempts`; do
-    if [[ $attempt -gt 1 ]]; then
-      echo "Attempt $attempt of $attempts"
-    fi
-    # This weird construction lets us capture return codes under -o errexit
-    "$@" && local rc=$? || local rc=$?
-    if [[ ! $rc -eq $exit_code ]]; then
-      return $rc
-    fi
-    if [[ $attempt -eq $attempts ]]; then
-      return $rc
-    fi
-    local sleep_ms="$(($attempt * $attempt * $sleep_millis))"
-    sleep "${sleep_ms:0:-3}.${sleep_ms: -3}"
-  done
+MAX_RETRIES=100
+MAX_TIMEOUT=1800
+
+
+function get_random_number() {
+    local start=$1
+    local end=$2
+    local range_len=$(($end - $start))
+
+    echo $(( ($RANDOM % $range_len) + $start ))
 }
+
+function to_power() {
+    local base=$1
+    local power=$2
+    echo "$base^$power" | bc
+}
+
+function run_with_exponential_backoff() {
+    local cmd=$*
+    local timeout=1
+    local failcount=0
+    local secret=
+    local return_code=1
+
+    while :
+    do
+	set +e
+        secret=`$cmd`
+        return_code=$?
+	set -e
+        if [[ $return_code -eq 0 ]]
+        then
+            break
+	fi
+
+    #this will add a non linear exponential backoff
+    timeout=$(( `get_random_number 0 1` + `to_power $failcount 2` ))
+	failcount=$(( $failcount + 1 ))
+
+        if [[ $failcount -ge $MAX_RETRIES ]]
+        then
+            >&2 echo Maximum number of retries of $MAX_RETRIES reached...
+            exit 2
+	fi
+
+        if [[ $timeout -gt $MAX_TIMEOUT ]]
+        then
+            timeout=$MAX_TIMEOUT
+	fi
+
+        >&2 echo Will retry in ${timeout}s...
+        sleep $timeout
+    done
+
+    echo $secret
+}
+
 # Join function
 # Downloads the kubeadm token and execute it
 # $1: bucket+key where token is located
@@ -37,9 +74,6 @@ S3_BUCKET_NAME=$1
 JOIN_TOKEN_URL="s3://${S3_BUCKET_NAME}/join/join.sh"
 ALERT_MANAGER_HOSTNAME=$2
 
-RETRIES=300
-RETRY_SECONDS=10
-
 n=0
 fail_join=1
 me=`basename "$0"`
@@ -50,5 +84,5 @@ SLEEP_MILLISECS=1000
 
 join_command=$(join $JOIN_TOKEN_URL && fail_join=0 && break)
 
-err_retry 2 $MAX_ATTEMPTS $SLEEP_MILLISECS $join_command || notify $ALERT_MANAGER_HOSTNAME "warning" "Cloud-init script is failing. /$me causes this warning"
+run_with_exponential_backoff $join_command || notify $ALERT_MANAGER_HOSTNAME "warning" "Cloud-init script is failing. /$me causes this warning"
 echo "fail all attempts to join cluster"; exit $fail_join

--- a/roles/kube-node-common/files/auto-join-node.sh
+++ b/roles/kube-node-common/files/auto-join-node.sh
@@ -2,7 +2,27 @@
 
 source /cloud-init-report-alert.sh
 
-
+function err_retry() {
+  local exit_code=$1
+  local attempts=$2
+  local sleep_millis=$3
+  shift 3
+  for attempt in `seq 1 $attempts`; do
+    if [[ $attempt -gt 1 ]]; then
+      echo "Attempt $attempt of $attempts"
+    fi
+    # This weird construction lets us capture return codes under -o errexit
+    "$@" && local rc=$? || local rc=$?
+    if [[ ! $rc -eq $exit_code ]]; then
+      return $rc
+    fi
+    if [[ $attempt -eq $attempts ]]; then
+      return $rc
+    fi
+    local sleep_ms="$(($attempt * $attempt * $sleep_millis))"
+    sleep "${sleep_ms:0:-3}.${sleep_ms: -3}"
+  done
+}
 # Join function
 # Downloads the kubeadm token and execute it
 # $1: bucket+key where token is located
@@ -24,11 +44,11 @@ n=0
 fail_join=1
 me=`basename "$0"`
 
-until [ $n -ge $RETRIES ]
-do
-   join $JOIN_TOKEN_URL && fail_join=0 && break
-   n=$[$n+1]
-   notify $ALERT_MANAGER_HOSTNAME "warning" "Cloud-init script is failing. /$me causes this warning"
-   sleep $RETRY_SECONDS
-done
-exit $fail_join
+MAX_ATTEMPTS=50
+
+SLEEP_MILLISECS=1000
+
+join_command=$(join $JOIN_TOKEN_URL && fail_join=0 && break)
+
+err_retry 2 $MAX_ATTEMPTS $SLEEP_MILLISECS $join_command || notify $ALERT_MANAGER_HOSTNAME "warning" "Cloud-init script is failing. /$me causes this warning"
+echo "fail all attempts to join cluster"; exit $fail_join

--- a/roles/kube-node-common/files/auto-join-node.sh
+++ b/roles/kube-node-common/files/auto-join-node.sh
@@ -44,7 +44,7 @@ n=0
 fail_join=1
 me=`basename "$0"`
 
-MAX_ATTEMPTS=50
+MAX_ATTEMPTS=200
 
 SLEEP_MILLISECS=1000
 


### PR DESCRIPTION
Due to race condition happened just yesterday on timing between provisioning and make the
cluster up and running,i am introducing a first version of an
exponential backoff, in order to avoid these kind of situations again. Probably the err_retry function could be externalized in a source file like the alert one.  I supposed that the exit code error is `2`, please correct it if am supposing it wrong!