### PR TITLE
opening ingress traffic for BGP and IPIP ports to make calico work

### DIFF
--- a/docs/AMI.md
+++ b/docs/AMI.md
@@ -28,18 +28,18 @@ Contains only furyagent installed.
 
 | Name                                      | Fury Version | AMI                   | Region       | Kind    |
 |-------------------------------------------|--------------|-----------------------|--------------|---------|
-| KFD-Ubuntu-Master-1.15.5-2-1572436070     | 1.15.4-2     | ami-07bf0537ace102ba4 | eu-central-1 | Master  |
-| KFD-Ubuntu-Node-1.15.5-2-1572436071       | 1.15.4-2     | ami-026eaa3e3ca8827ce | eu-central-1 | Node    |
-| KFD-Ubuntu-Bastion-1.15.5-2-1572436070    | 1.15.4-2     | ami-0326230e05b7f29a8 | eu-central-1 | Bastion |
-| KFD-Ubuntu-Master-1.15.5-2-1572436070     | 1.15.4-2     | ami-02100b6018d7b17c5 | eu-north-1   | Master  |
-| KFD-Ubuntu-Node-1.15.5-2-1572436071       | 1.15.4-2     | ami-06a1e980e801cc6f2 | eu-north-1   | Node    |
-| KFD-Ubuntu-Bastion-1.15.5-2-1572436070    | 1.15.4-2     | ami-0d8d6e2b63cd2f0be | eu-north-1   | Bastion |
-| KFD-Ubuntu-Master-1.15.5-2-1572436070     | 1.15.4-2     | ami-0c3f77ab96e04e208 | eu-west-1    | Master  |
-| KFD-Ubuntu-Node-1.15.5-2-1572436071       | 1.15.4-2     | ami-02b3cd4c27a9c0139 | eu-west-1    | Node    |
-| KFD-Ubuntu-Bastion-1.15.5-2-1572436070    | 1.15.4-2     | ami-0c4d3c3b952e38ee6 | eu-west-1    | Bastion |
-| KFD-Ubuntu-Master-1.15.5-2-1572436070     | 1.15.4-2     | ami-081b37e491554ad36 | eu-west-2    | Master  |
-| KFD-Ubuntu-Node-1.15.5-2-1572436071       | 1.15.4-2     | ami-048dfff321b0f0dac | eu-west-2    | Node    |
-| KFD-Ubuntu-Bastion-1.15.5-2-1572436070    | 1.15.4-2     | ami-03a696cd31c95d10a | eu-west-2    | Bastion |
-| KFD-Ubuntu-Master-1.15.5-2-1572436070     | 1.15.4-2     | ami-055b703f134ba9c72 | eu-west-3    | Master  |
-| KFD-Ubuntu-Node-1.15.5-2-1572436071       | 1.15.4-2     | ami-0ac1df9ab2d92bba7 | eu-west-3    | Node    |
-| KFD-Ubuntu-Bastion-1.15.5-2-1572436070    | 1.15.4-2     | ami-023651eb3e778c6fd | eu-west-3    | Bastion |
+| KFD-Ubuntu-Master-1.15.5-2-1579779741     | 1.15.4-5     | ami-09405f10a0a6999ce | eu-central-1 | Master  |
+| KFD-Ubuntu-Node-1.15.5-2-1579779741       | 1.15.4-5     | ami-05494483088483273 | eu-central-1 | Node    |
+| KFD-Ubuntu-Bastion-1.15.5-2-1579779740    | 1.15.4-5     | ami-00b729abab1b2af46 | eu-central-1 | Bastion |
+| KFD-Ubuntu-Master-1.15.5-2-1579779741     | 1.15.4-5     | ami-0949f1c78ef318fbe | eu-north-1   | Master  |
+| KFD-Ubuntu-Node-1.15.5-2-1579779741       | 1.15.4-5     | ami-0ff227891ed844760 | eu-north-1   | Node    |
+| KFD-Ubuntu-Bastion-1.15.5-2-1579779740    | 1.15.4-5     | ami-00b729abab1b2af46 | eu-north-1   | Bastion |
+| KFD-Ubuntu-Master-1.15.5-2-1579779741     | 1.15.4-5     | ami-08e79902f55bbd13f | eu-west-1    | Master  |
+| KFD-Ubuntu-Node-1.15.5-2-1579779741       | 1.15.4-5     | ami-0cbba18efeef096f6 | eu-west-1    | Node    |
+| KFD-Ubuntu-Bastion-1.15.5-2-1579779740    | 1.15.4-5     | ami-0f5e60c0a1e1f9ff5 | eu-west-1    | Bastion |
+| KFD-Ubuntu-Master-1.15.5-2-1579779741     | 1.15.4-5     | ami-07362dc85fb207740 | eu-west-2    | Master  |
+| KFD-Ubuntu-Node-1.15.5-2-1579779741       | 1.15.4-5     | ami-09a8ae2a05f70b570 | eu-west-2    | Node    |
+| KFD-Ubuntu-Bastion-1.15.5-2-1579779740    | 1.15.4-5     | ami-0bebf58296f86d308 | eu-west-2    | Bastion |
+| KFD-Ubuntu-Master-1.15.5-2-1579779741     | 1.15.4-5     | ami-02a9d50b47c9b2fef | eu-west-3    | Master  |
+| KFD-Ubuntu-Node-1.15.5-2-1579779741       | 1.15.4-5     | ami-0d3235975e9f3ae87 | eu-west-3    | Node    |
+| KFD-Ubuntu-Bastion-1.15.5-2-1579779740    | 1.15.4-5     | ami-023651eb3e778c6fd | eu-west-3    | Bastion |

--- a/docs/releases/v1.15.4-5.md
+++ b/docs/releases/v1.15.4-5.md
@@ -1,0 +1,64 @@
+# Release notes
+
+- [Release notes](#release-notes)
+  - [Calico](#calico)
+    - [Use case](#use-case)
+    - [Issue](#issue)
+    - [Change](#change)
+      - [How to deploy it](#how-to-deploy-it)
+        - [Requirements](#requirements)
+        - [Before deploy](#before-deploy)
+        - [Applying it](#applying-it)
+        - [Verify](#verify)
+
+This version contains a patch in the [`aws-kubernetes` terraform module](modules/aws-kubernetes) that fixes a problem
+related to Calico CNI.
+
+## Calico
+
+### Use case
+
+Fury Kubernetes Cluster Using calico from fury-kubernetes-networking.
+
+### Issue
+
+Missing open Calico ports for BGP. Documented here: https://docs.projectcalico.org/v2.3/reference/public-cloud/aws
+
+### Change
+
+Open:
+
+BGP: TCP: 179
+IPIP: IPIP: all ports
+
+#### How to deploy it
+
+##### Requirements
+
+Having version 1.15.4 deployed, change the version to 1.15.4-5 in your `Furyfile.yml`, then:
+
+```bash
+$ furyctl install
+```
+
+This command downloads the patch in your `vendor/modules/aws/aws-kubernetes` directory.
+
+##### Before deploy
+
+You can check terraform plans before applying the new configuration.
+
+```bash
+$ terraform plan
+```
+
+##### Applying it
+
+If everything is fine with the terraform plan, we are ready to go!
+
+```bash
+$ terraform apply -auto-approve
+```
+
+##### Verify
+
+Check the ports are opened in the `master` and `node` security groups.

--- a/modules/aws-kubernetes/sg.tf
+++ b/modules/aws-kubernetes/sg.tf
@@ -145,6 +145,24 @@ resource "aws_security_group_rule" "k8s-master-ssh" {
   security_group_id = "${aws_security_group.kubernetes-master.id}"
 }
 
+resource "aws_security_group_rule" "k8s-master-BGP" {
+  type              = "ingress"
+  from_port         = 179
+  to_port           = 179
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = "${aws_security_group.kubernetes-master.id}"
+}
+
+resource "aws_security_group_rule" "k8s-master-IPP" {
+  type              = "ingress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = 94
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = "${aws_security_group.kubernetes-master.id}"
+}
+
 resource "aws_security_group_rule" "k8s-master-apiserver" {
   type              = "ingress"
   from_port         = 6443

--- a/modules/aws-kubernetes/sg.tf
+++ b/modules/aws-kubernetes/sg.tf
@@ -18,6 +18,24 @@ resource "aws_security_group_rule" "k8s-node-ssh" {
   security_group_id = "${aws_security_group.kubernetes-nodes.id}"
 }
 
+resource "aws_security_group_rule" "k8s-node-BGP" {
+  type              = "ingress"
+  from_port         = 179
+  to_port           = 179
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = "${aws_security_group.kubernetes-nodes.id}"
+}
+
+resource "aws_security_group_rule" "k8s-node-IPP" {
+  type              = "ingress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = 94
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = "${aws_security_group.kubernetes-nodes.id}"
+}
+
 resource "aws_security_group_rule" "k8s-node-apiserver" {
   type              = "ingress"
   from_port         = 10250


### PR DESCRIPTION
As specified [here](https://docs.projectcalico.org/v2.3/reference/public-cloud/aws) we should open the needed ports between nodes in order to allow BGP and IPIP.

For some reason the updated [documentation](https://docs.projectcalico.org/v3.11/reference/public-cloud/aws) is not reporting these ports, but I've tested it and it's working.

We should probably also disable the "src/dst checks" for the instances, but I have to dig further on it, and at the moment it looks like everything is working fine even without it.