### PR TITLE
[Hotfix] Deactivate src dest check

### DIFF
--- a/docs/releases/v1.15.4-6.md
+++ b/docs/releases/v1.15.4-6.md
@@ -1,0 +1,64 @@
+# Release notes
+
+- [Release notes](#release-notes)
+  - [Calico](#calico)
+    - [Use case](#use-case)
+    - [Issue](#issue)
+    - [Change](#change)
+      - [How to deploy it](#how-to-deploy-it)
+        - [Requirements](#requirements)
+        - [Before deploy](#before-deploy)
+        - [Applying it](#applying-it)
+        - [Verify](#verify)
+
+This version contains a patch in the [`aws-kubernetes` terraform module](modules/aws-kubernetes) that fixes a problem
+related to Calico CNI (again).
+
+## Calico
+
+### Use case
+
+Fury Kubernetes Cluster Using calico from fury-kubernetes-networking.
+
+### Issue
+
+Calico requires to have disabled the src/dst check. 
+Documented here: https://docs.projectcalico.org/v2.3/reference/public-cloud/aws
+
+### Change
+
+Disable src/dst checks in master and worker nodes
+
+#### How to deploy it
+
+##### Requirements
+
+Having version 1.15.4 deployed, change the version to 1.15.4-6 in your `Furyfile.yml`, then:
+
+```bash
+$ furyctl install
+```
+
+This command downloads the patch in your `vendor/modules/aws/aws-kubernetes` directory.
+
+##### Before deploy
+
+You can check terraform plans before applying the new configuration.
+
+```bash
+$ terraform plan
+```
+
+##### Applying it
+
+If everything is fine with the terraform plan, we are ready to go!
+
+```bash
+$ terraform apply -auto-approve
+```
+
+The change in master nodes are automatically while worker nodes needs to be destroyed and recreated.
+
+##### Verify
+
+Check if the src/dst check is disabled from the ec2 console.

--- a/modules/aws-kubernetes/cloudinit/worker-join.yml
+++ b/modules/aws-kubernetes/cloudinit/worker-join.yml
@@ -15,6 +15,24 @@ write_files:
       KUBELET_EXTRA_ARGS='--cloud-provider=aws --node-labels=node-kind.sighup.io/${kind}="" --node-labels=node-role.kubernetes.io/${kind}=""'
     path: /etc/default/kubelet
     permissions: '0644'
+  - content: |
+      [Unit]
+      Description=Disable EC2 source/dest check
+      Requires=docker.service
+      After=docker.service
+      
+      [Service]
+      Type=oneshot
+      RemainAfterExit=yes
+      ExecStart=/usr/bin/docker run --net=host --rm rubenv/ec2-disable-source-dest
+      
+      [Install]
+      WantedBy=multi-user.target
+    path: /lib/systemd/system/ec2-disable-source-dest.service
+    permissions: '0644'
 runcmd:
+- systemctl daemon-reload
+- systemctl enable ec2-disable-source-dest.service
+- systemctl start --no-block ec2-disable-source-dest.service
 - /cloud-init-report.sh ${alertmanager_hostname} &>/dev/null &
 - /auto-join-node.sh ${s3_bucket_name} ${alertmanager_hostname}

--- a/modules/aws-kubernetes/cloudinit/worker-join.yml
+++ b/modules/aws-kubernetes/cloudinit/worker-join.yml
@@ -15,24 +15,10 @@ write_files:
       KUBELET_EXTRA_ARGS='--cloud-provider=aws --node-labels=node-kind.sighup.io/${kind}="" --node-labels=node-role.kubernetes.io/${kind}=""'
     path: /etc/default/kubelet
     permissions: '0644'
-  - content: |
-      [Unit]
-      Description=Disable EC2 source/dest check
-      Requires=docker.service
-      After=docker.service
-      
-      [Service]
-      Type=oneshot
-      RemainAfterExit=yes
-      ExecStart=/usr/bin/docker run --net=host --rm rubenv/ec2-disable-source-dest
-      
-      [Install]
-      WantedBy=multi-user.target
-    path: /lib/systemd/system/ec2-disable-source-dest.service
-    permissions: '0644'
 runcmd:
-- systemctl daemon-reload
-- systemctl enable ec2-disable-source-dest.service
-- systemctl start --no-block ec2-disable-source-dest.service
 - /cloud-init-report.sh ${alertmanager_hostname} &>/dev/null &
+- AWS_AZ="$(curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone)"
+- AWS_REGION="$(echo $AWS_AZ | sed 's/.$//')"
+- INSTANCE_ID="$(curl -s http://169.254.169.254/latest/meta-data/instance-id)"
+- aws ec2 modify-instance-attribute --no-source-dest-check --instance-id ${INSTANCE_ID} --region ${AWS_REGION}
 - /auto-join-node.sh ${s3_bucket_name} ${alertmanager_hostname}

--- a/modules/aws-kubernetes/kube-master.tf
+++ b/modules/aws-kubernetes/kube-master.tf
@@ -6,6 +6,7 @@ resource "aws_instance" "k8s-master" {
   subnet_id              = "${element(data.aws_subnet.private.*.id, count.index)}"
   iam_instance_profile   = "${aws_iam_instance_profile.main.name}"
   vpc_security_group_ids = ["${aws_security_group.kubernetes-master.id}"]
+  source_dest_check      = false
 
   root_block_device {
     volume_type           = "gp2"


### PR DESCRIPTION
Hi team!

I need help with this Issue / PR.

As we are deploying calico CNI by default, we have to deactivate the src dest check.
On Master nodes is solved, just added the attribute to the `ec2_instance` terraform resource.
The problem is within the worker nodes.

Launch configuration resource does not provide a way to deactivate the src dest check, so we have to do it "manually".

I found some alternatives:

As a "plain script" in the cloud-init userdata:

- https://stackoverflow.com/questions/57504230/source-dest-check-in-aws-launch-configuration-in-terraform
- Using a unit with a docker container (with a golang sw): https://github.com/rubenv/ec2-disable-source-dest

Additional info:

I tried to create an ec2 instance with the same AMI as we are using for the auto-join feature.
Also i have used the worker-join userdata cloud-init configuration (without some attributes).

~~But i can not make it working. ~~

~~1st problem: The unit file is not written.~~
~~2nd problem: If you try the container, it needs EC2 permissions.~~

~~Please, i need help with this.~~ I have create a trello card to track it: https://trello.com/c/605OYtQ6

Thanks!