### PR TITLE
Change internal-zone behaviour on vpc module

### DIFF
--- a/modules/aws-vpc/input.tf
+++ b/modules/aws-vpc/input.tf
@@ -34,7 +34,6 @@ variable "region" {
 
 variable "internal-zone" {
   type        = "string"
-  default     = "staging.k8s.sighup.io"
   description = "Domain name for internal services"
 }
 

--- a/modules/aws-vpc/input.tf
+++ b/modules/aws-vpc/input.tf
@@ -34,7 +34,7 @@ variable "region" {
 
 variable "internal-zone" {
   type        = "string"
-  default     = "sighup.io"
+  default     = "staging.k8s.sighup.io"
   description = "Domain name for internal services"
 }
 

--- a/modules/aws-vpc/route53.tf
+++ b/modules/aws-vpc/route53.tf
@@ -1,5 +1,5 @@
 resource "aws_route53_zone" "main" {
-  name = "${var.env}.${var.name}.${var.internal-zone}"
+  name = "${var.internal-zone}"
 
   vpc {
     vpc_id = "${aws_vpc.main.id}"


### PR DESCRIPTION
Hi everyone, as discussed with @lnovara , the vpc module should have as input the complete domain that will be used as a private zone . This modification is due to low readability of what the module is doing hence creating confusion.

The new usage of the module should be:

```hcl-terraform
module "vpc" {
  source        = "../../vendor/modules/aws/aws-vpc"
  name          = "fury"
  env           = "staging"
  vpc-cidr      = "10.100.0.0/16"
  region        = "${var.aws_region}"
  internal-zone = "staging.fury.sighup.io"

  ssh-public-keys = [
    "${file("../../secrets/ssh-user.pub")}",
  ]
}
```