### PR TITLE
Use furyagent latest instead of a pinned version

### DIFF
--- a/packer/playbook-bastion.yaml
+++ b/packer/playbook-bastion.yaml
@@ -2,6 +2,6 @@
   hosts: all
   become: true
   vars:
-    furyagent_uri: https://github.com/sighupio/furyagent/releases/download/v0.0.8/furyagent-linux-amd64
+    furyagent_uri: https://github.com/sighupio/furyagent/releases/latest/download/furyagent-linux-amd64
   roles:
     - ../../roles/furyagent

--- a/packer/playbook-master.yaml
+++ b/packer/playbook-master.yaml
@@ -12,6 +12,6 @@
   hosts: all
   become: true
   vars:
-    furyagent_uri: https://github.com/sighupio/furyagent/releases/download/v0.0.8/furyagent-linux-amd64
+    furyagent_uri: https://github.com/sighupio/furyagent/releases/latest/download/furyagent-linux-amd64
   roles:
     - ../../roles/furyagent

--- a/packer/playbook-node.yaml
+++ b/packer/playbook-node.yaml
@@ -12,6 +12,6 @@
   hosts: all
   become: true
   vars:
-    furyagent_uri: https://github.com/sighupio/furyagent/releases/download/v0.0.8/furyagent-linux-amd64
+    furyagent_uri: https://github.com/sighupio/furyagent/releases/latest/download/furyagent-linux-amd64
   roles:
     - ../../roles/furyagent


### PR DESCRIPTION
So we don't have to keep updating manually the roles when we release newer versions of furyagent