### PR TITLE
Added permission policy on ecr repos to permit another AWS account to ecr:* actions

### DIFF
--- a/modules/aws-kubernetes/ecr_access.tf
+++ b/modules/aws-kubernetes/ecr_access.tf
@@ -1,0 +1,20 @@
+resource "aws_ecr_repository_policy" "main" {
+  count      = "${var.ecr-additional-pull-account-id != "" ? length(var.ecr-repositories) : 0}"
+  repository = "${element(aws_ecr_repository.main.*.name, count.index)}"
+
+  policy = <<EOF
+{
+  "Version": "2008-10-17",
+  "Statement": [
+    {
+      "Sid": "Allow${var.ecr-additional-pull-account-id}",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::${var.ecr-additional-pull-account-id}:root"
+      },
+      "Action": "ecr:*"
+    }
+  ]
+}
+EOF
+}

--- a/modules/aws-kubernetes/input.tf
+++ b/modules/aws-kubernetes/input.tf
@@ -268,3 +268,8 @@ variable "node-role-tag-cluster-autoscaler" {
   default = "node-role.kubernetes.io"
   type    = "string"
 }
+
+variable "ecr-additional-pull-account-id" {
+  default = ""
+  type    = "string"
+}


### PR DESCRIPTION
Added a new parameter on aws-kubernetes module to add a permission policy on all the ECR repos managed.

This way another account can pull/push etc on the ecr repos