### PR TITLE
Added ignore changes on desired_capacity for ASG.

### DIFF
--- a/modules/aws-kubernetes/kube-worker-spot.tf
+++ b/modules/aws-kubernetes/kube-worker-spot.tf
@@ -84,5 +84,6 @@ resource "aws_autoscaling_group" "spot" {
 
   lifecycle {
     create_before_destroy = true
+    ignore_changes = ["desired_capacity"]
   }
 }

--- a/modules/aws-kubernetes/kube-worker.tf
+++ b/modules/aws-kubernetes/kube-worker.tf
@@ -63,6 +63,7 @@ resource "aws_autoscaling_group" "main" {
 
   lifecycle {
     create_before_destroy = true
+    ignore_changes = ["desired_capacity"]
   }
 }
 


### PR DESCRIPTION
When autoscaling group are currently scaled up or down and they are different from the desired asg, terraform wants to change the desired number of instances. Adding this lifecycle ignores that change.