### PR TITLE
Update s3-furyagent module to Terraform 0.12

### DIFF
--- a/modules/s3-furyagent/README.md
+++ b/modules/s3-furyagent/README.md
@@ -1,12 +1,12 @@
-# aws-ark
+# s3-furyagent
 
 This module is useful to create all the things necessary for furyagent to work
 and to be provisioned.
 
 # Usage
 ```hcl
-module "aws-furyagent" {
-    source = "../vendor/modules/aws-furyagent"
+module "s3-furyagent" {
+    source = "../vendor/modules/s3-furyagent"
     cluster_name = "sighup"
     environment = "production"
     aws_region = "eu-west-1"

--- a/modules/s3-furyagent/output.tf
+++ b/modules/s3-furyagent/output.tf
@@ -10,17 +10,17 @@ EOF
 }
 
 output "furyagent_ansible_secrets" {
-  value = "${local.furyagent_ansible_secrets}"
+  value = local.furyagent_ansible_secrets
 }
 
 output "bucket_username" {
-  value = "${aws_iam_user.main.name}"
+  value = aws_iam_user.main.name
 }
 
 output "bucket_policy" {
-  value = "${aws_iam_policy.main.arn}"
+  value = aws_iam_policy.main.arn
 }
 
 output "bucket_policy_join" {
-  value = "${aws_iam_policy.join.arn}"
+  value = aws_iam_policy.join.arn
 }

--- a/modules/s3-furyagent/s3.tf
+++ b/modules/s3-furyagent/s3.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket" "main" {
-  bucket = "${var.furyagent_bucket_name}"
+  bucket = var.furyagent_bucket_name
   acl    = "private"
 
   lifecycle_rule {
@@ -29,9 +29,9 @@ resource "aws_s3_bucket" "main" {
     }
   }
 
-  tags {
-    Name        = "${var.furyagent_bucket_name}"
-    Cluster     = "${var.cluster_name}"
-    Environment = "${var.environment}"
+  tags = {
+    Name        = var.furyagent_bucket_name
+    Cluster     = var.cluster_name
+    Environment = var.environment
   }
 }

--- a/modules/s3-furyagent/user.tf
+++ b/modules/s3-furyagent/user.tf
@@ -5,12 +5,12 @@ resource "aws_iam_user" "main" {
 
 resource "aws_iam_policy_attachment" "main" {
   name       = "${var.cluster_name}-${var.environment}-furyagent-backup"
-  users      = ["${aws_iam_user.main.name}"]
-  policy_arn = "${aws_iam_policy.main.arn}"
+  users      = [aws_iam_user.main.name]
+  policy_arn = aws_iam_policy.main.arn
 }
 
 resource "aws_iam_access_key" "main" {
-  user = "${aws_iam_user.main.name}"
+  user = aws_iam_user.main.name
 }
 
 resource "aws_iam_policy" "main" {


### PR DESCRIPTION
Even if this repository is deprecated in favor of [sighupio/fury-eks-installer](https://github.com/sighupio/fury-eks-installer) we still need to support it. Therefore I am updating the code of `s3-furyagent` module to be used with Terraform 0.12.x.