### PR TITLE
Update aws-vpc module to Terraform 0.12

### DIFF
--- a/modules/aws-vpc/bastion.tf
+++ b/modules/aws-vpc/bastion.tf
@@ -1,91 +1,91 @@
 resource "aws_instance" "bastion" {
-  count                       = "${var.bastion-count}"
-  ami                         = "${data.aws_ami.main.id}"
-  instance_type               = "${var.bastion-instance-type}"
-  user_data                   = "${data.template_cloudinit_config.config.rendered}"
-  subnet_id                   = "${element(aws_subnet.public.*.id, count.index)}"
+  count                       = var.bastion-count
+  ami                         = data.aws_ami.main.id
+  instance_type               = var.bastion-instance-type
+  user_data                   = data.template_cloudinit_config.config.rendered
+  subnet_id                   = element(aws_subnet.public.*.id, count.index)
   associate_public_ip_address = true
-  vpc_security_group_ids      = ["${aws_security_group.bastion.id}"]
+  vpc_security_group_ids      = [aws_security_group.bastion.id]
 
   root_block_device {
     volume_type = "gp2"
     volume_size = 50
   }
 
-  tags {
-    Name = "bastion-${var.name}-${var.env}-${count.index+1}"
+  tags = {
+    Name = "bastion-${var.name}-${var.env}-${count.index + 1}"
     Role = "bastion"
   }
 
   lifecycle {
-    ignore_changes = ["ami"]
+    ignore_changes = [ami]
   }
 }
 
 resource "aws_eip" "bastion" {
-  count      = "${var.bastion-count}"
-  depends_on = ["aws_internet_gateway.main"]
+  count      = var.bastion-count
+  depends_on = [aws_internet_gateway.main]
 
-  tags {
-    Name = "bastion-${var.name}-${var.env}-${count.index+1}"
+  tags = {
+    Name = "bastion-${var.name}-${var.env}-${count.index + 1}"
   }
 }
 
 resource "aws_eip_association" "bastion" {
-  count         = "${var.bastion-count}"
-  instance_id   = "${element(aws_instance.bastion.*.id, count.index)}"
-  allocation_id = "${element(aws_eip.bastion.*.id, count.index)}"
+  count         = var.bastion-count
+  instance_id   = element(aws_instance.bastion.*.id, count.index)
+  allocation_id = element(aws_eip.bastion.*.id, count.index)
 }
 
 resource "aws_security_group" "bastion" {
   name   = "bastion-${var.env}"
-  vpc_id = "${aws_vpc.main.id}"
+  vpc_id = aws_vpc.main.id
 
-  tags {
+  tags = {
     Name = "bastion-${var.name}-${var.env}"
   }
 }
 
 resource "aws_security_group_rule" "egress" {
-  count       = "${var.bastion-ssh-enable}"
   type        = "egress"
   from_port   = 0
   to_port     = 0
   protocol    = "-1"
   cidr_blocks = ["0.0.0.0/0"]
 
-  security_group_id = "${aws_security_group.bastion.id}"
+  security_group_id = aws_security_group.bastion.id
 }
 
 resource "aws_security_group_rule" "ssh" {
-  count       = "${var.bastion-ssh-enable}"
+  count       = var.bastion-ssh-enable ? 1 : 0
   type        = "ingress"
   from_port   = 22
   to_port     = 22
   protocol    = "TCP"
   cidr_blocks = ["0.0.0.0/0"]
 
-  security_group_id = "${aws_security_group.bastion.id}"
+  security_group_id = aws_security_group.bastion.id
 }
 
 resource "aws_security_group_rule" "vpn-tcp" {
-  count       = "${var.bastion-vpn-enable}"
+  count       = var.bastion-vpn-enable ? 1 : 0
   type        = "ingress"
   from_port   = 1194
   to_port     = 1194
   protocol    = "TCP"
   cidr_blocks = ["0.0.0.0/0"]
 
-  security_group_id = "${aws_security_group.bastion.id}"
+  security_group_id = aws_security_group.bastion.id
 }
 
 resource "aws_security_group_rule" "vpn-udp" {
-  count       = "${var.bastion-vpn-enable}"
+  count       = var.bastion-vpn-enable ? 1 : 0
   type        = "ingress"
   from_port   = 1194
   to_port     = 1194
   protocol    = "UDP"
   cidr_blocks = ["0.0.0.0/0"]
 
-  security_group_id = "${aws_security_group.bastion.id}"
+  security_group_id = aws_security_group.bastion.id
 }
+

--- a/modules/aws-vpc/cloudinit.tf
+++ b/modules/aws-vpc/cloudinit.tf
@@ -1,17 +1,17 @@
 data "template_file" "ssh_keys" {
-  count    = "${length(var.ssh-public-keys)}"
+  count    = length(var.ssh-public-keys)
   template = "- $${ssh-public-key}"
 
-  vars {
-    ssh-public-key = "${element("${var.ssh-public-keys}", count.index)}"
+  vars = {
+    ssh-public-key = element(var.ssh-public-keys, count.index)
   }
 }
 
 data "template_file" "cloud-init" {
-  template = "${file("${path.module}/cloudinit/userdata-template.yml")}"
+  template = file("${path.module}/cloudinit/userdata-template.yml")
 
-  vars {
-    ssh-authorized-keys = "${indent(2, join("\n", "${data.template_file.ssh_keys.*.rendered}"))}"
+  vars = {
+    ssh-authorized-keys = indent(2, join("\n", data.template_file.ssh_keys.*.rendered))
   }
 }
 
@@ -21,6 +21,7 @@ data "template_cloudinit_config" "config" {
   part {
     filename     = "ssh-authorized-keys.cfg"
     content_type = "text/cloud-config"
-    content      = "${data.template_file.cloud-init.rendered}"
+    content      = data.template_file.cloud-init.rendered
   }
 }
+

--- a/modules/aws-vpc/input.tf
+++ b/modules/aws-vpc/input.tf
@@ -1,83 +1,84 @@
 variable "vpc-cidr" {
-  type    = "string"
+  type    = string
   default = "10.10.0.0/16"
 }
 
 variable "az-count" {
-  type        = "string"
+  type        = number
   description = "Number of az to deploy the VPC in"
   default     = 3
 }
 
 variable "bastion-vpn-enable" {
-  type    = "string"
+  type    = bool
   default = true
 }
 
 variable "bastion-ssh-enable" {
-  type    = "string"
+  type    = bool
   default = true
 }
 
 variable "name" {
-  type = "string"
+  type = string
 }
 
 variable "env" {
-  type = "string"
+  type = string
 }
 
 variable "region" {
-  type    = "string"
+  type    = string
   default = "eu-west-1"
 }
 
 variable "internal-zone" {
-  type        = "string"
+  type        = string
   description = "Domain name for internal services"
 }
 
 variable "additional-zone" {
-  type        = "string"
+  type        = string
   default     = ""
   description = "Additional domain name for internal services"
 }
 
 variable "bastion-instance-type" {
-  type    = "string"
+  type    = string
   default = "t3.small"
 }
 
 variable "bastion-count" {
-  type    = "string"
+  type    = number
   default = 2
 }
 
 variable "bastion-ami" {
-  type    = "string"
+  type    = string
   default = "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*"
 }
 
 variable "ssh-public-keys" {
-  type        = "list"
+  type        = list(string)
   description = "List of public SSH keys authorized to connect to the bastions"
 }
 
 variable "bastion-ami-owner" {
-  type = "string"
-  default = "099720109477"
+  type        = string
+  default     = "099720109477"
   description = "Bastion nodes AMI Owner"
 }
 
-
 data "aws_ami" "main" {
   most_recent = true
-  owners = ["${var.bastion-ami-owner}"]
+  owners      = [var.bastion-ami-owner]
 
   filter {
     name   = "name"
-    values = ["${var.bastion-ami}"]
+    values = [var.bastion-ami]
   }
 }
 
-data "aws_availability_zones" "available" {}
+data "aws_availability_zones" "available" {
+}
+

--- a/modules/aws-vpc/ouput.tf
+++ b/modules/aws-vpc/ouput.tf
@@ -29,3 +29,19 @@ output "bastion_public_ip" {
 output "main_internet_gateway" {
   value = aws_internet_gateway.main.id
 }
+
+output "route_table_public" {
+  value = aws_route_table.public.id
+}
+
+output "route_table_private" {
+  value = aws_route_table.private.*.id
+}
+
+output "vpn_security_group" {
+  value = aws_security_group.bastion.id
+}
+
+output "nat_gateway_ids" {
+  value = aws_nat_gateway.main.*.id
+}

--- a/modules/aws-vpc/ouput.tf
+++ b/modules/aws-vpc/ouput.tf
@@ -1,31 +1,31 @@
 output "vpc" {
-  value = "${aws_vpc.main.id}"
+  value = aws_vpc.main.id
 }
 
 output "public_subnets" {
-  value = "${flatten(aws_subnet.public.*.id)}"
+  value = aws_subnet.public.*.id
 }
 
 output "private_subnets" {
-  value = "${flatten(aws_subnet.private.*.id)}"
+  value = aws_subnet.private.*.id
 }
 
 output "domain_zone" {
-  value = "${aws_route53_zone.main.id}"
+  value = aws_route53_zone.main.id
 }
 
 output "additional_zone" {
-  value = "${aws_route53_zone.additional.*.id}"
+  value = aws_route53_zone.additional.*.id
 }
 
 output "bastion_private_ip" {
-  value = "${flatten(aws_instance.bastion.*.private_ip)}"
+  value = aws_instance.bastion.*.private_ip
 }
 
 output "bastion_public_ip" {
-  value = "${flatten(aws_eip.bastion.*.public_ip)}"
+  value = aws_eip.bastion.*.public_ip
 }
 
 output "main_internet_gateway" {
-  value = "${aws_internet_gateway.main.id}"
+  value = aws_internet_gateway.main.id
 }

--- a/modules/aws-vpc/private.tf
+++ b/modules/aws-vpc/private.tf
@@ -1,3 +1,10 @@
+locals {
+  private_subnet_tags = map(
+    "kubernetes.io/cluster/${var.name}-${var.env}", "shared",
+    "kubernetes.io/role/internal-elb", "1"
+  )
+}
+
 resource "aws_subnet" "private" {
   count                   = var.az-count
   availability_zone       = data.aws_availability_zones.available.names[count.index]
@@ -5,9 +12,12 @@ resource "aws_subnet" "private" {
   cidr_block              = cidrsubnet(var.vpc-cidr, 8, count.index + 10)
   map_public_ip_on_launch = false
 
-  tags = {
-    Name = "private-${var.name}-${var.env}-${count.index}"
-  }
+  tags = merge(
+    local.private_subnet_tags,
+    map(
+      "Name", "private-${var.name}-${var.env}-${count.index}"
+    )
+  )
 }
 
 resource "aws_route_table" "private" {

--- a/modules/aws-vpc/private.tf
+++ b/modules/aws-vpc/private.tf
@@ -1,33 +1,34 @@
 resource "aws_subnet" "private" {
-  count                   = "${var.az-count}"
-  availability_zone       = "${data.aws_availability_zones.available.names[count.index]}"
-  vpc_id                  = "${aws_vpc.main.id}"
-  cidr_block              = "${cidrsubnet(var.vpc-cidr, 8, count.index+10)}"
+  count                   = var.az-count
+  availability_zone       = data.aws_availability_zones.available.names[count.index]
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = cidrsubnet(var.vpc-cidr, 8, count.index + 10)
   map_public_ip_on_launch = false
 
-  tags {
+  tags = {
     Name = "private-${var.name}-${var.env}-${count.index}"
   }
 }
 
 resource "aws_route_table" "private" {
-  vpc_id = "${aws_vpc.main.id}"
-  count  = "${var.az-count}"
+  vpc_id = aws_vpc.main.id
+  count  = var.az-count
 
-  tags {
-    Name = "private-${var.name}-${var.env}-${count.index+1}"
+  tags = {
+    Name = "private-${var.name}-${var.env}-${count.index + 1}"
   }
 }
 
 resource "aws_route" "private" {
-  count                  = "${var.az-count}"
-  route_table_id         = "${element(aws_route_table.private.*.id,count.index)}"
-  nat_gateway_id         = "${element(aws_nat_gateway.main.*.id,count.index)}"
+  count                  = var.az-count
+  route_table_id         = element(aws_route_table.private.*.id, count.index)
+  nat_gateway_id         = element(aws_nat_gateway.main.*.id, count.index)
   destination_cidr_block = "0.0.0.0/0"
 }
 
 resource "aws_route_table_association" "private" {
-  count          = "${var.az-count}"
-  subnet_id      = "${element(aws_subnet.private.*.id, count.index)}"
-  route_table_id = "${element(aws_route_table.private.*.id, count.index)}"
+  count          = var.az-count
+  subnet_id      = element(aws_subnet.private.*.id, count.index)
+  route_table_id = element(aws_route_table.private.*.id, count.index)
 }
+

--- a/modules/aws-vpc/public.tf
+++ b/modules/aws-vpc/public.tf
@@ -1,3 +1,10 @@
+locals {
+  public_subnet_tags = map(
+    "kubernetes.io/cluster/${var.name}-${var.env}", "shared",
+    "kubernetes.io/role/elb", "1"
+  )
+}
+
 resource "aws_subnet" "public" {
   count                   = var.az-count
   availability_zone       = data.aws_availability_zones.available.names[count.index]
@@ -5,9 +12,12 @@ resource "aws_subnet" "public" {
   cidr_block              = cidrsubnet(var.vpc-cidr, 8, count.index)
   map_public_ip_on_launch = true
 
-  tags = {
-    Name = "public-${var.name}-${var.env}-${count.index}"
-  }
+  tags = merge(
+    local.public_subnet_tags,
+    map(
+      "Name", "public-${var.name}-${var.env}-${count.index}"
+    )
+  )
 }
 
 resource "aws_internet_gateway" "main" {

--- a/modules/aws-vpc/public.tf
+++ b/modules/aws-vpc/public.tf
@@ -1,56 +1,57 @@
 resource "aws_subnet" "public" {
-  count                   = "${var.az-count}"
-  availability_zone       = "${data.aws_availability_zones.available.names[count.index]}"
-  vpc_id                  = "${aws_vpc.main.id}"
-  cidr_block              = "${cidrsubnet(var.vpc-cidr, 8, count.index)}"
+  count                   = var.az-count
+  availability_zone       = data.aws_availability_zones.available.names[count.index]
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = cidrsubnet(var.vpc-cidr, 8, count.index)
   map_public_ip_on_launch = true
 
-  tags {
+  tags = {
     Name = "public-${var.name}-${var.env}-${count.index}"
   }
 }
 
 resource "aws_internet_gateway" "main" {
-  vpc_id = "${aws_vpc.main.id}"
+  vpc_id = aws_vpc.main.id
 }
 
 resource "aws_eip" "main" {
-  count      = "${var.az-count}"
+  count      = var.az-count
   vpc        = true
-  depends_on = ["aws_internet_gateway.main"]
+  depends_on = [aws_internet_gateway.main]
 
-  tags {
-    Name = "nat-${var.name}-${var.env}-${count.index+1}"
+  tags = {
+    Name = "nat-${var.name}-${var.env}-${count.index + 1}"
   }
 }
 
 resource "aws_nat_gateway" "main" {
-  count         = "${var.az-count}"
-  allocation_id = "${element(aws_eip.main.*.id, count.index)}"
-  subnet_id     = "${element(aws_subnet.public.*.id,count.index)}"
-  depends_on    = ["aws_internet_gateway.main"]
+  count         = var.az-count
+  allocation_id = element(aws_eip.main.*.id, count.index)
+  subnet_id     = element(aws_subnet.public.*.id, count.index)
+  depends_on    = [aws_internet_gateway.main]
 
-  tags {
-    Name = "nat-${var.name}-${var.env}-${count.index+1}"
+  tags = {
+    Name = "nat-${var.name}-${var.env}-${count.index + 1}"
   }
 }
 
 resource "aws_route_table" "public" {
-  vpc_id = "${aws_vpc.main.id}"
+  vpc_id = aws_vpc.main.id
 
-  tags {
+  tags = {
     Name = "public-${var.name}-${var.env}"
   }
 }
 
 resource "aws_route" "main" {
-  route_table_id         = "${aws_route_table.public.id}"
-  gateway_id             = "${aws_internet_gateway.main.id}"
+  route_table_id         = aws_route_table.public.id
+  gateway_id             = aws_internet_gateway.main.id
   destination_cidr_block = "0.0.0.0/0"
 }
 
 resource "aws_route_table_association" "public" {
-  count          = "${var.az-count}"
-  subnet_id      = "${element(aws_subnet.public.*.id,count.index)}"
-  route_table_id = "${aws_route_table.public.id}"
+  count          = var.az-count
+  subnet_id      = element(aws_subnet.public.*.id, count.index)
+  route_table_id = aws_route_table.public.id
 }
+

--- a/modules/aws-vpc/route53.tf
+++ b/modules/aws-vpc/route53.tf
@@ -1,16 +1,17 @@
 resource "aws_route53_zone" "main" {
-  name = "${var.internal-zone}"
+  name = var.internal-zone
 
   vpc {
-    vpc_id = "${aws_vpc.main.id}"
+    vpc_id = aws_vpc.main.id
   }
 }
 
 resource "aws_route53_zone" "additional" {
-  count = "${var.additional-zone == "" ? 0 : 1}"
-  name  = "${var.additional-zone}"
+  count = var.additional-zone == "" ? 0 : 1
+  name  = var.additional-zone
 
   vpc {
-    vpc_id = "${aws_vpc.main.id}"
+    vpc_id = aws_vpc.main.id
   }
 }
+

--- a/modules/aws-vpc/versions.tf
+++ b/modules/aws-vpc/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_version = "~> 0.12"
+  required_providers {
+    aws      = "~> 2.65"
+    template = "~> 2.1"
+  }
+}

--- a/modules/aws-vpc/vpc.tf
+++ b/modules/aws-vpc/vpc.tf
@@ -1,10 +1,19 @@
+locals {
+  vpc_tags = map(
+    "kubernetes.io/cluster/${var.name}-${var.env}", "shared",
+  )
+}
+
 resource "aws_vpc" "main" {
   cidr_block           = var.vpc-cidr
   enable_dns_support   = true
   enable_dns_hostnames = true
 
-  tags = {
-    Name = "vpc-${var.name}-${var.env}"
-  }
+  tags = merge(
+    local.vpc_tags,
+    map(
+      "Name", "vpc-${var.name}-${var.env}",
+    )
+  )
 }
 

--- a/modules/aws-vpc/vpc.tf
+++ b/modules/aws-vpc/vpc.tf
@@ -1,9 +1,10 @@
 resource "aws_vpc" "main" {
-  cidr_block           = "${var.vpc-cidr}"
+  cidr_block           = var.vpc-cidr
   enable_dns_support   = true
   enable_dns_hostnames = true
 
-  tags {
+  tags = {
     Name = "vpc-${var.name}-${var.env}"
   }
 }
+


### PR DESCRIPTION
Even if this repository is deprecated in favor of [sighupio/fury-eks-installer](https://github.com/sighupio/fury-eks-installer) we still need to support it. Therefore I am updating the code of `aws-vpc` module to be used with Terraform 0.12.x.

Summary of changes:
  - updated HCL syntax to Terraform 0.12
  - added some useful outputs
  - added kubernetes tags to network resources to make service `type: LoadBalancer` work

This PR is related to sighupio/fury-kubernetes-aws#45, I chose to split the two PRs to ease the review process. If that's not the case, I can merge them. Let me know.