### PR TITLE
Update aws-kubernetes module to Terraform 0.12

### DIFF
--- a/modules/aws-kubernetes/aim.tf
+++ b/modules/aws-kubernetes/aim.tf
@@ -1,29 +1,29 @@
 resource "aws_iam_role" "main" {
   name               = "${var.name}-${var.env}-kubernetes-role"
-  assume_role_policy = "${file("${path.module}/policies/assume-role.json")}"
+  assume_role_policy = file("${path.module}/policies/assume-role.json")
 }
 
 resource "aws_iam_policy" "main" {
   name   = "${var.name}-${var.env}-kubernetes-policy"
-  policy = "${file("${path.module}/policies/kubernetes.json")}"
+  policy = file("${path.module}/policies/kubernetes.json")
 }
 
 resource "aws_iam_policy_attachment" "main" {
   name       = "${var.name}-${var.env}-kubernetes-instance-attachment"
-  roles      = ["${aws_iam_role.main.name}"]
-  policy_arn = "${aws_iam_policy.main.arn}"
+  roles      = [aws_iam_role.main.name]
+  policy_arn = aws_iam_policy.main.arn
 }
 
 resource "aws_iam_instance_profile" "main" {
   name = "${var.name}-${var.env}-kubernetes-instance-profile"
-  role = "${aws_iam_role.main.name}"
+  role = aws_iam_role.main.name
 }
 
 resource "aws_iam_policy_attachment" "join" {
   name       = "${var.name}-${var.env}-kubernetes-worker-join"
-  roles      = ["${aws_iam_role.main.name}"]
-  users      = ["${aws_iam_user.furyagent_worker.name}"]
-  policy_arn = "${var.join-policy-arn}"
+  roles      = [aws_iam_role.main.name]
+  users      = [aws_iam_user.furyagent_worker.name]
+  policy_arn = var.join-policy-arn
 }
 
 resource "aws_iam_user" "furyagent_worker" {
@@ -32,5 +32,6 @@ resource "aws_iam_user" "furyagent_worker" {
 }
 
 resource "aws_iam_access_key" "furyagent_worker" {
-  user = "${aws_iam_user.furyagent_worker.name}"
+  user = aws_iam_user.furyagent_worker.name
 }
+

--- a/modules/aws-kubernetes/cloudinit.tf
+++ b/modules/aws-kubernetes/cloudinit.tf
@@ -1,29 +1,29 @@
 data "template_file" "ssh_keys" {
-  count    = "${length(var.ssh-public-keys)}"
+  count    = length(var.ssh-public-keys)
   template = "- $${ssh-public-key}"
 
-  vars {
-    ssh-public-key = "${element("${var.ssh-public-keys}", count.index)}"
+  vars = {
+    ssh-public-key = element(var.ssh-public-keys, count.index)
   }
 }
 
 data "template_file" "cloud-init-keys" {
-  template = "${file("${path.module}/cloudinit/userdata-template.yml")}"
+  template = file("${path.module}/cloudinit/userdata-template.yml")
 
-  vars {
-    ssh-authorized-keys = "${indent(2, join("\n", "${data.template_file.ssh_keys.*.rendered}"))}"
+  vars = {
+    ssh-authorized-keys = indent(2, join("\n", data.template_file.ssh_keys.*.rendered))
   }
 }
 
 data "template_file" "cloud-init-workers" {
-  count    = "${length(var.kube-workers)}"
-  template = "${file("${path.module}/cloudinit/worker-join.yml")}"
+  count    = length(var.kube-workers)
+  template = file("${path.module}/cloudinit/worker-join.yml")
 
-  vars {
-    kind                  = "${lookup(var.kube-workers[count.index], "kind")}"
-    alertmanager_hostname = "${var.alertmanager-hostname}"
-    ssh-authorized-keys   = "${indent(2, join("\n", "${data.template_file.ssh_keys.*.rendered}"))}"
-    furyagent             = "${data.template_file.furyagent.rendered}"
+  vars = {
+    kind                  = var.kube-workers[count.index]["kind"]
+    alertmanager_hostname = var.alertmanager-hostname
+    ssh-authorized-keys   = indent(2, join("\n", data.template_file.ssh_keys.*.rendered))
+    furyagent             = data.template_file.furyagent.rendered
   }
 }
 
@@ -33,51 +33,55 @@ data "template_cloudinit_config" "config_master" {
   part {
     filename     = "ssh-authorized-keys.cfg"
     content_type = "text/cloud-config"
-    content      = "${data.template_file.cloud-init-keys.rendered}"
+    content      = data.template_file.cloud-init-keys.rendered
   }
 }
 
 data "template_cloudinit_config" "config_worker" {
-  count = "${length(var.kube-workers)}"
+  count = length(var.kube-workers)
   gzip  = false
 
   part {
     filename     = "workers-init.cfg"
     content_type = "text/cloud-config"
-    content      = "${element(data.template_file.cloud-init-workers.*.rendered, count.index)}"
+    content = element(
+      data.template_file.cloud-init-workers.*.rendered,
+      count.index,
+    )
   }
 }
 
 data "template_file" "furyagent" {
-  template = "${file("${path.module}/worker-furyagent/furyagent.yml.tmpl")}"
+  template = file("${path.module}/worker-furyagent/furyagent.yml.tmpl")
 
-  vars {
-    aws_access_key = "${aws_iam_access_key.furyagent_worker.id}"
-    aws_secret_key = "${aws_iam_access_key.furyagent_worker.secret}"
-    s3_bucket_name = "${var.s3-bucket-name}"
-    s3_region      = "${var.region}"
+  vars = {
+    aws_access_key = aws_iam_access_key.furyagent_worker.id
+    aws_secret_key = aws_iam_access_key.furyagent_worker.secret
+    s3_bucket_name = var.s3-bucket-name
+    s3_region      = var.region
   }
 }
 
 data "template_file" "cloud-init-spot" {
-  count    = "${length(var.kube-workers-spot)}"
-  template = "${file("${path.module}/cloudinit/worker-join.yml")}"
+  count    = length(var.kube-workers-spot)
+  template = file("${path.module}/cloudinit/worker-join.yml")
 
-  vars {
-    kind                  = "${lookup(var.kube-workers-spot[count.index], "kind")}"
-    alertmanager_hostname = "${var.alertmanager-hostname}"
-    ssh-authorized-keys   = "${indent(2, join("\n", "${data.template_file.ssh_keys.*.rendered}"))}"
-    furyagent             = "${data.template_file.furyagent.rendered}"
+  vars = {
+    kind                  = var.kube-workers-spot[count.index]["kind"]
+    alertmanager_hostname = var.alertmanager-hostname
+    ssh-authorized-keys   = indent(2, join("\n", data.template_file.ssh_keys.*.rendered))
+    furyagent             = data.template_file.furyagent.rendered
   }
 }
 
 data "template_cloudinit_config" "config_spot" {
-  count = "${length(var.kube-workers-spot)}"
+  count = length(var.kube-workers-spot)
   gzip  = false
 
   part {
     filename     = "workers-init.cfg"
     content_type = "text/cloud-config"
-    content      = "${element(data.template_file.cloud-init-spot.*.rendered, count.index)}"
+    content      = element(data.template_file.cloud-init-spot.*.rendered, count.index)
   }
 }
+

--- a/modules/aws-kubernetes/cloudinit/worker-join.yml
+++ b/modules/aws-kubernetes/cloudinit/worker-join.yml
@@ -12,7 +12,7 @@ users:
   ${ssh-authorized-keys}
 write_files:
   - content: |
-      KUBELET_EXTRA_ARGS='--cloud-provider=aws --node-labels=node-kind.sighup.io/${kind}="" --node-labels=node-role.kubernetes.io/${kind}=""'
+      KUBELET_EXTRA_ARGS='--cloud-provider=aws --node-labels=node-kind.sighup.io/${kind}="" --node-labels=node.kubernetes.io/role=${kind}'
     path: /etc/default/kubelet
     permissions: '0644'
   - content: |

--- a/modules/aws-kubernetes/ecr.tf
+++ b/modules/aws-kubernetes/ecr.tf
@@ -27,8 +27,7 @@ resource "aws_ecr_lifecycle_policy" "main" {
             "rulePriority": 2,
             "description": "Keep last 100 images",
             "selection": {
-                "tagStatus": "tagged",
-                "tagPrefixList": ["v"],
+                "tagStatus": "any",
                 "countType": "imageCountMoreThan",
                 "countNumber": 100
             },

--- a/modules/aws-kubernetes/ecr.tf
+++ b/modules/aws-kubernetes/ecr.tf
@@ -1,11 +1,11 @@
 resource "aws_ecr_repository" "main" {
-  count = "${length(var.ecr-repositories)}"
-  name  = "${element(var.ecr-repositories, count.index)}"
+  count = length(var.ecr-repositories)
+  name  = element(var.ecr-repositories, count.index)
 }
 
 resource "aws_ecr_lifecycle_policy" "main" {
-  count      = "${length(var.ecr-repositories)}"
-  repository = "${element(aws_ecr_repository.main.*.name, count.index)}"
+  count      = length(var.ecr-repositories)
+  repository = element(aws_ecr_repository.main.*.name, count.index)
 
   policy = <<EOF
 {
@@ -39,6 +39,7 @@ resource "aws_ecr_lifecycle_policy" "main" {
     ]
 }
 EOF
+
 }
 
 resource "aws_iam_user" "pusher" {
@@ -48,12 +49,12 @@ resource "aws_iam_user" "pusher" {
 
 resource "aws_iam_policy_attachment" "pusher" {
   name       = "${var.name}-${var.env}-ecr-pusher"
-  users      = ["${aws_iam_user.pusher.name}"]
-  policy_arn = "${aws_iam_policy.pusher.arn}"
+  users      = [aws_iam_user.pusher.name]
+  policy_arn = aws_iam_policy.pusher.arn
 }
 
 resource "aws_iam_access_key" "pusher" {
-  user = "${aws_iam_user.pusher.name}"
+  user = aws_iam_user.pusher.name
 }
 
 resource "aws_iam_policy" "pusher" {
@@ -84,6 +85,7 @@ resource "aws_iam_policy" "pusher" {
     ]
 }
 EOF
+
 }
 
 locals {
@@ -94,8 +96,10 @@ export AWS_DEFAULT_REGION=${var.region}
 # `aws ecr get-login --no-include-email --region eu-west-1`
 #${join("\n#", aws_ecr_repository.main.*.repository_url)}
 EOF
+
 }
 
 output "ecr-pusher" {
-  value = "${local.ecr-pusher}"
+  value = local.ecr-pusher
 }
+

--- a/modules/aws-kubernetes/ecr_access.tf
+++ b/modules/aws-kubernetes/ecr_access.tf
@@ -1,6 +1,6 @@
 resource "aws_ecr_repository_policy" "main" {
-  count      = "${var.ecr-additional-pull-account-id != "" ? length(var.ecr-repositories) : 0}"
-  repository = "${element(aws_ecr_repository.main.*.name, count.index)}"
+  count      = var.ecr-additional-pull-account-id != "" ? length(var.ecr-repositories) : 0
+  repository = element(aws_ecr_repository.main.*.name, count.index)
 
   policy = <<EOF
 {
@@ -17,4 +17,6 @@ resource "aws_ecr_repository_policy" "main" {
   ]
 }
 EOF
+
 }
+

--- a/modules/aws-kubernetes/input.tf
+++ b/modules/aws-kubernetes/input.tf
@@ -1,48 +1,51 @@
-variable name {
-  type        = "string"
+variable "name" {
+  type        = string
   description = "Cluster name"
 }
 
-variable env {
-  type        = "string"
+variable "env" {
+  type        = string
   description = "Cluster environment"
 }
 
-variable region {
-  type        = "string"
+variable "region" {
+  type        = string
   default     = "eu-west-1"
   description = "AWS region"
 }
 
-variable kube-master-count {
-  type        = "string"
+variable "kube-master-count" {
+  type        = string
   default     = 1
   description = "Number of Kubernetes master nodes"
 }
 
-variable kube-master-type {
-  type        = "string"
+variable "kube-master-type" {
+  type        = string
   default     = "t3.medium"
   description = "Kubernetes master nodes EC2 instance type"
 }
 
-variable kube-master-volumes {
-  type        = "list"
+variable "kube-master-volumes" {
+  type = list(object({
+    size        = number
+    type        = string
+    iops        = number
+    device_name = string
+  }))
   default     = []
   description = "Kubernetes master nodes volumes"
 }
 
-# kube-master-volumes = [
-#   {
-#     size = 10,
-#     type = gp2,
-#     iops = ...,
-#     device_name = /dev/sdf
-#   }
-# ]
-
-variable kube-workers {
-  type        = "list"
+variable "kube-workers" {
+  type = list(object({
+    kind     = string
+    min      = number
+    desired  = number
+    max      = number
+    type     = string
+    kube-ami = string
+  }))
   description = "List of maps holding definition of Kubernetes workers"
 }
 
@@ -65,8 +68,16 @@ variable kube-workers {
 #   },
 # ]
 
-variable kube-workers-spot {
-  type        = "list"
+variable "kube-workers-spot" {
+  type = list(object({
+    kind           = string
+    min            = number
+    desired        = number
+    max            = number
+    type           = string
+    type_secondary = string
+    kube-ami       = string
+  }))
   description = "List of maps holding definition of Kubernetes workers spot"
 }
 
@@ -90,55 +101,67 @@ variable kube-workers-spot {
 # ]
 
 variable "kube-workers-ami-owner" {
-  type        = "string"
+  type        = string
   default     = "363601582189"
   description = "Kubernetes workers AMI Owner"
 }
 
-variable kube-master-ami {
-  type        = "string"
+variable "kube-master-ami" {
+  type        = string
   default     = "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*"
   description = "Kubernetes nodes AMI"
 }
 
 variable "kube-master-ami-owner" {
-  type        = "string"
+  type        = string
   default     = "099720109477"
   description = "Kubernetes nodes AMI Owner"
 }
 
-variable kube-lb-internal-domains {
-  type        = "list"
+variable "kube-lb-internal-domains" {
+  type        = list(string)
   default     = []
   description = "List of domains to be created for internal loadbalancer on Kubernetes DNS zone"
 }
 
-variable kube-lb-internal-additional-domains {
-  type        = "list"
+variable "kube-lb-internal-additional-domains" {
+  type        = list(string)
   default     = []
   description = "List of domains to be created for internal loadbalancer on additional DNS zone"
 }
 
-variable kube-lb-external-domains {
-  type        = "list"
+variable "kube-lb-external-domains" {
+  type        = list(string)
   default     = []
   description = "List of domains for TLS termination on external loadbalancer"
 }
 
-variable kube-lb-external-enable-access-log {
-  type        = "string"
+variable "kube-lb-external-enable-access-log" {
+  type        = string
   default     = false
   description = "Enable access log on external load balancer"
 }
 
-variable kube-master-security-group {
-  type        = "list"
+variable "kube-master-security-group" {
+  type = list(object({
+    type        = string
+    to_port     = number
+    from_port   = number
+    protocol    = string
+    cidr_blocks = string
+  }))
   default     = []
   description = "Kubernetes master security group rules"
 }
 
-variable kube-workers-security-group {
-  type        = "list"
+variable "kube-workers-security-group" {
+  type = list(object({
+    type        = string
+    to_port     = number
+    from_port   = number
+    protocol    = string
+    cidr_blocks = string
+  }))
   default     = []
   description = "Kubernetes workers security group rules"
 }
@@ -153,52 +176,52 @@ variable kube-workers-security-group {
 #   }
 # ]
 
-variable kube-private-subnets {
-  type        = "list"
+variable "kube-private-subnets" {
+  type        = list(string)
   description = "List of AWS private subnet IDs"
 }
 
-variable kube-public-subnets {
-  type        = "list"
+variable "kube-public-subnets" {
+  type        = list(string)
   description = "List of AWS public subnet IDs"
 }
 
-variable kube-bastions {
-  type        = "list"
+variable "kube-bastions" {
+  type        = list(string)
   description = "List of bastion public IP addresses"
 }
 
-variable kube-domain {
-  type        = "string"
+variable "kube-domain" {
+  type        = string
   description = "Route53 Kubernetes zone ID"
 }
 
-variable additional-domain {
-  type        = "string"
+variable "additional-domain" {
+  type        = string
   default     = ""
   description = "Route53 additional zone ID"
 }
 
-variable ssh-public-keys {
-  type        = "list"
+variable "ssh-public-keys" {
+  type        = list(string)
   description = "List of public SSH keys authorized to connect to Kubernetes nodes"
 }
 
-variable ssh-private-key {
-  type        = "string"
+variable "ssh-private-key" {
+  type        = string
   description = "Path to own private key to access machines"
 }
 
-variable ecr-repositories {
-  type        = "list"
+variable "ecr-repositories" {
+  type        = list(string)
   description = "List of docker image repositories to create"
 }
 
-variable s3-bucket-name {
+variable "s3-bucket-name" {
   description = "furyagent auxiliary bucket name"
 }
 
-variable join-policy-arn {
+variable "join-policy-arn" {
   description = "policy granting access to kubeadm generated token to workers"
 }
 
@@ -209,67 +232,68 @@ variable "alertmanager-hostname" {
 
 data "aws_ami" "master" {
   most_recent = true
-  owners      = ["${var.kube-master-ami-owner}"]
+  owners      = [var.kube-master-ami-owner]
 
   filter {
     name   = "name"
-    values = ["${var.kube-master-ami}"]
+    values = [var.kube-master-ami]
   }
 }
 
 data "aws_ami" "worker" {
-  count       = "${length(var.kube-workers)}"
+  count       = length(var.kube-workers)
   most_recent = true
-  owners      = ["${var.kube-workers-ami-owner}"]
+  owners      = [var.kube-workers-ami-owner]
 
   filter {
     name   = "name"
-    values = ["${lookup(var.kube-workers[count.index], "kube-ami")}"]
+    values = [var.kube-workers[count.index]["kube-ami"]]
   }
 }
 
 data "aws_ami" "spot" {
-  count       = "${length(var.kube-workers-spot)}"
+  count       = length(var.kube-workers-spot)
   most_recent = true
-  owners      = ["${var.kube-workers-ami-owner}"]
+  owners      = [var.kube-workers-ami-owner]
 
   filter {
     name   = "name"
-    values = ["${lookup(var.kube-workers-spot[count.index], "kube-ami")}"]
+    values = [var.kube-workers-spot[count.index]["kube-ami"]]
   }
 }
 
 data "aws_subnet" "private" {
-  count = "${length(var.kube-private-subnets)}"
-  id    = "${element(var.kube-private-subnets, count.index)}"
+  count = length(var.kube-private-subnets)
+  id    = element(var.kube-private-subnets, count.index)
 }
 
 data "aws_subnet" "public" {
-  count = "${length(var.kube-public-subnets)}"
-  id    = "${element(var.kube-public-subnets, count.index)}"
+  count = length(var.kube-public-subnets)
+  id    = element(var.kube-public-subnets, count.index)
 }
 
 data "aws_vpc" "main" {
-  id = "${data.aws_subnet.private.0.vpc_id}"
+  id = data.aws_subnet.private[0].vpc_id
 }
 
 data "aws_route53_zone" "main" {
-  zone_id = "${var.kube-domain}"
+  zone_id = var.kube-domain
 }
 
 data "aws_route53_zone" "additional" {
-  count   = "${var.additional-domain == "" ? 0 : 1}"
-  zone_id = "${var.additional-domain}"
+  count   = var.additional-domain == "" ? 0 : 1
+  zone_id = var.additional-domain
 }
 
 #node-role.kubernetes.io
 
 variable "node-role-tag-cluster-autoscaler" {
   default = "node-role.kubernetes.io"
-  type    = "string"
+  type    = string
 }
 
 variable "ecr-additional-pull-account-id" {
   default = ""
-  type    = "string"
+  type    = string
 }
+

--- a/modules/aws-kubernetes/input.tf
+++ b/modules/aws-kubernetes/input.tf
@@ -45,6 +45,7 @@ variable "kube-workers" {
     max      = number
     type     = string
     kube-ami = string
+    disk     = string
   }))
   description = "List of maps holding definition of Kubernetes workers"
 }
@@ -57,6 +58,7 @@ variable "kube-workers" {
 #     max = 3
 #     type = "m5.large"
 #     kube-ami= "KFD-Ubuntu-Infra-1571399626"
+#     disk = 80
 #   },
 #   {
 #     kind = "production"
@@ -64,7 +66,8 @@ variable "kube-workers" {
 #     desired = 2
 #     max = 2
 #     type = "c5.large"
-#     kube-ami= "KFD-Ubuntu-Worker-1571399626"
+#     kube-ami = "KFD-Ubuntu-Worker-1571399626"
+#     disk = 50
 #   },
 # ]
 
@@ -77,6 +80,7 @@ variable "kube-workers-spot" {
     type           = string
     type_secondary = string
     kube-ami       = string
+    disk           = string
   }))
   description = "List of maps holding definition of Kubernetes workers spot"
 }
@@ -89,6 +93,7 @@ variable "kube-workers-spot" {
 #     max = 2
 #     type = "m5.large"
 #     kube-ami= "KFD-Ubuntu-Infra-1571399626"
+#     disk = 80
 #   },
 #   {
 #     kind = "stateless"
@@ -97,6 +102,7 @@ variable "kube-workers-spot" {
 #     max = 2
 #     type = "c5.large"
 #     kube-ami= "KFD-Ubuntu-Worker-1571399626"
+#     disk = 50
 #   },
 # ]
 

--- a/modules/aws-kubernetes/input.tf
+++ b/modules/aws-kubernetes/input.tf
@@ -280,9 +280,15 @@ data "aws_route53_zone" "main" {
   zone_id = var.kube-domain
 }
 
+variable "additional_private" {
+  type = "string"
+  default = "false"
+}
+
 data "aws_route53_zone" "additional" {
   count   = var.additional-domain == "" ? 0 : 1
   zone_id = var.additional-domain
+  private_zone = "${var.additional_private}"
 }
 
 #node-role.kubernetes.io

--- a/modules/aws-kubernetes/input.tf
+++ b/modules/aws-kubernetes/input.tf
@@ -287,14 +287,14 @@ data "aws_route53_zone" "main" {
 }
 
 variable "additional_private" {
-  type = "string"
+  type    = string
   default = "false"
 }
 
 data "aws_route53_zone" "additional" {
-  count   = var.additional-domain == "" ? 0 : 1
-  zone_id = var.additional-domain
-  private_zone = "${var.additional_private}"
+  count        = var.additional-domain == "" ? 0 : 1
+  zone_id      = var.additional-domain
+  private_zone = var.additional_private
 }
 
 #node-role.kubernetes.io
@@ -311,5 +311,5 @@ variable "ecr-additional-pull-account-id" {
 
 variable "enable_weekday_workers_shutdown" {
   default = false
-  type    = "string"
+  type    = string
 }

--- a/modules/aws-kubernetes/input.tf
+++ b/modules/aws-kubernetes/input.tf
@@ -303,3 +303,7 @@ variable "ecr-additional-pull-account-id" {
   type    = string
 }
 
+variable "enable_weekday_workers_shutdown" {
+  default = false
+  type    = "string"
+}

--- a/modules/aws-kubernetes/kube-master.tf
+++ b/modules/aws-kubernetes/kube-master.tf
@@ -1,11 +1,11 @@
 resource "aws_instance" "k8s-master" {
-  count                  = "${var.kube-master-count}"
-  ami                    = "${data.aws_ami.master.id}"
-  instance_type          = "${var.kube-master-type}"
-  user_data              = "${data.template_cloudinit_config.config_master.rendered}"
-  subnet_id              = "${element(data.aws_subnet.private.*.id, count.index)}"
-  iam_instance_profile   = "${aws_iam_instance_profile.main.name}"
-  vpc_security_group_ids = ["${aws_security_group.kubernetes-master.id}"]
+  count                  = var.kube-master-count
+  ami                    = data.aws_ami.master.id
+  instance_type          = var.kube-master-type
+  user_data              = data.template_cloudinit_config.config_master.rendered
+  subnet_id              = element(data.aws_subnet.private.*.id, count.index)
+  iam_instance_profile   = aws_iam_instance_profile.main.name
+  vpc_security_group_ids = [aws_security_group.kubernetes-master.id]
   source_dest_check      = false
 
   root_block_device {
@@ -14,7 +14,7 @@ resource "aws_instance" "k8s-master" {
     delete_on_termination = "true"
   }
 
-  tags {
+  tags = {
     Name              = "kube-master-${var.name}-${var.env}-${count.index + 1}"
     Role              = "master"
     Gated             = "true"
@@ -23,28 +23,35 @@ resource "aws_instance" "k8s-master" {
 }
 
 resource "aws_volume_attachment" "k8s-master" {
-  count       = "${length(var.kube-master-volumes) * var.kube-master-count}"
-  device_name = "${lookup(var.kube-master-volumes[(count.index / var.kube-master-count) % length(var.kube-master-volumes)], "device_name")}"
-  instance_id = "${element(aws_instance.k8s-master.*.id, count.index % var.kube-master-count)}"
-  volume_id   = "${element(aws_ebs_volume.k8s-master.*.id, count.index)}"
+  count       = length(var.kube-master-volumes) * var.kube-master-count
+  device_name = var.kube-master-volumes[count.index / var.kube-master-count % length(var.kube-master-volumes)]["device_name"]
+  instance_id = element(
+    aws_instance.k8s-master.*.id,
+    count.index % var.kube-master-count,
+  )
+  volume_id = element(aws_ebs_volume.k8s-master.*.id, count.index)
 }
 
 resource "aws_ebs_volume" "k8s-master" {
-  count             = "${length(var.kube-master-volumes) * var.kube-master-count}"
-  size              = "${lookup(var.kube-master-volumes[(count.index / var.kube-master-count) % length(var.kube-master-volumes)], "size")}"
-  type              = "${lookup(var.kube-master-volumes[(count.index / var.kube-master-count) % length(var.kube-master-volumes)], "type")}"
-  iops              = "${lookup(var.kube-master-volumes[(count.index / var.kube-master-count) % length(var.kube-master-volumes)], "iops")}"
-  availability_zone = "${element(aws_instance.k8s-master.*.availability_zone, count.index % var.kube-master-count)}"
+  count = length(var.kube-master-volumes) * var.kube-master-count
+  size  = var.kube-master-volumes[count.index / var.kube-master-count % length(var.kube-master-volumes)]["size"]
+  type  = var.kube-master-volumes[count.index / var.kube-master-count % length(var.kube-master-volumes)]["type"]
+  iops  = var.kube-master-volumes[count.index / var.kube-master-count % length(var.kube-master-volumes)]["iops"]
+  availability_zone = element(
+    aws_instance.k8s-master.*.availability_zone,
+    count.index % var.kube-master-count,
+  )
 }
 
 resource "aws_route53_record" "k8s-master" {
-  count   = "${var.kube-master-count}"
-  zone_id = "${var.kube-domain}"
+  count   = var.kube-master-count
+  zone_id = var.kube-domain
   name    = "master-${count.index + 1}"
   type    = "A"
   ttl     = "600"
 
   records = [
-    "${element(aws_instance.k8s-master.*.private_ip, count.index)}",
+    element(aws_instance.k8s-master.*.private_ip, count.index),
   ]
 }
+

--- a/modules/aws-kubernetes/kube-worker-spot.tf
+++ b/modules/aws-kubernetes/kube-worker-spot.tf
@@ -20,7 +20,8 @@ resource "aws_launch_template" "spot" {
   }
 
   network_interfaces {
-    security_groups = [aws_security_group.kubernetes-nodes.id]
+    security_groups       = [aws_security_group.kubernetes-nodes.id]
+    delete_on_termination = true
   }
 
   lifecycle {

--- a/modules/aws-kubernetes/kube-worker-spot.tf
+++ b/modules/aws-kubernetes/kube-worker-spot.tf
@@ -102,11 +102,11 @@ resource "aws_autoscaling_group" "spot" {
 resource "aws_autoscaling_schedule" "spot_workers_morning_start" {
   count                  = var.enable_weekday_workers_shutdown ? length(var.kube-workers-spot) : 0
   scheduled_action_name  = "Morning-Start-Schedule"
-  min_size               = var.kube-workers-spot[count.index][min]
-  max_size               = var.kube-workers-spot[count.index][max]
-  desired_capacity       = var.kube-workers-spot[count.index][desired]
+  min_size               = var.kube-workers-spot[count.index]["min"]
+  max_size               = var.kube-workers-spot[count.index]["max"]
+  desired_capacity       = var.kube-workers-spot[count.index]["desired"]
   recurrence             = "0 5 * * 1-5"
-  autoscaling_group_name = "${element(aws_autoscaling_group.spot.*.name, count.index)}"
+  autoscaling_group_name = element(aws_autoscaling_group.spot.*.name, count.index)
 }
 
 resource "aws_autoscaling_schedule" "spot_workers_afternoon_stop" {
@@ -116,5 +116,5 @@ resource "aws_autoscaling_schedule" "spot_workers_afternoon_stop" {
   max_size               = 0
   desired_capacity       = 0
   recurrence             = "45 23 * * *"
-  autoscaling_group_name = "${element(aws_autoscaling_group.spot.*.name, count.index)}"
+  autoscaling_group_name = element(aws_autoscaling_group.spot.*.name, count.index)
 }

--- a/modules/aws-kubernetes/kube-worker-spot.tf
+++ b/modules/aws-kubernetes/kube-worker-spot.tf
@@ -99,3 +99,22 @@ resource "aws_autoscaling_group" "spot" {
   }
 }
 
+resource "aws_autoscaling_schedule" "spot_workers_morning_start" {
+  count                  = var.enable_weekday_workers_shutdown ? length(var.kube-workers-spot) : 0
+  scheduled_action_name  = "Morning-Start-Schedule"
+  min_size               = var.kube-workers-spot[count.index][min]
+  max_size               = var.kube-workers-spot[count.index][max]
+  desired_capacity       = var.kube-workers-spot[count.index][desired]
+  recurrence             = "0 5 * * 1-5"
+  autoscaling_group_name = "${element(aws_autoscaling_group.spot.*.name, count.index)}"
+}
+
+resource "aws_autoscaling_schedule" "spot_workers_afternoon_stop" {
+  count                  = var.enable_weekday_workers_shutdown ? length(var.kube-workers-spot) : 0
+  scheduled_action_name  = "Afternoon-Stop-Schedule"
+  min_size               = 0
+  max_size               = 0
+  desired_capacity       = 0
+  recurrence             = "45 23 * * *"
+  autoscaling_group_name = "${element(aws_autoscaling_group.spot.*.name, count.index)}"
+}

--- a/modules/aws-kubernetes/kube-worker-spot.tf
+++ b/modules/aws-kubernetes/kube-worker-spot.tf
@@ -1,16 +1,19 @@
 resource "aws_launch_template" "spot" {
-  count         = "${length(var.kube-workers-spot)}"
-  name_prefix   = "${var.name}-${var.env}-k8s-${lookup(var.kube-workers-spot[count.index], "kind")}-nodes"
-  image_id      = "${element(data.aws_ami.spot.*.id, count.index)}"
-  instance_type = "${lookup(var.kube-workers-spot[count.index], "type")}"
-  user_data     = "${element(data.template_cloudinit_config.config_spot.*.rendered, count.index)}"
+  count         = length(var.kube-workers-spot)
+  name_prefix   = "${var.name}-${var.env}-k8s-${var.kube-workers-spot[count.index]["kind"]}-nodes"
+  image_id      = element(data.aws_ami.spot.*.id, count.index)
+  instance_type = var.kube-workers-spot[count.index]["type"]
+  user_data = element(
+    data.template_cloudinit_config.config_spot.*.rendered,
+    count.index,
+  )
 
   iam_instance_profile {
-    name = "${aws_iam_instance_profile.main.name}"
+    name = aws_iam_instance_profile.main.name
   }
 
   network_interfaces {
-    security_groups = ["${aws_security_group.kubernetes-nodes.id}"]
+    security_groups = [aws_security_group.kubernetes-nodes.id]
   }
 
   lifecycle {
@@ -19,27 +22,27 @@ resource "aws_launch_template" "spot" {
 }
 
 resource "aws_autoscaling_group" "spot" {
-  count                = "${length(var.kube-workers-spot)}"
-  name                 = "${var.name}-${var.env}-k8s-${lookup(var.kube-workers-spot[count.index], "kind")}-asg"
-  vpc_zone_identifier  = ["${flatten(data.aws_subnet.private.*.id)}"]
-  desired_capacity     = "${lookup(var.kube-workers-spot[count.index], "desired")}"
-  max_size             = "${lookup(var.kube-workers-spot[count.index], "max")}"
-  min_size             = "${lookup(var.kube-workers-spot[count.index], "min")}"
+  count                = length(var.kube-workers-spot)
+  name                 = "${var.name}-${var.env}-k8s-${var.kube-workers-spot[count.index]["kind"]}-asg"
+  vpc_zone_identifier  = data.aws_subnet.private.*.id
+  desired_capacity     = var.kube-workers-spot[count.index]["desired"]
+  max_size             = var.kube-workers-spot[count.index]["max"]
+  min_size             = var.kube-workers-spot[count.index]["min"]
   termination_policies = ["OldestInstance"]
 
   mixed_instances_policy {
     launch_template {
       launch_template_specification {
-        launch_template_id = "${element(aws_launch_template.spot.*.id,count.index)}"
-        version            = "${element(aws_launch_template.spot.*.latest_version,count.index)}"
+        launch_template_id = element(aws_launch_template.spot.*.id, count.index)
+        version            = element(aws_launch_template.spot.*.latest_version, count.index)
       }
 
       override {
-        instance_type = "${lookup(var.kube-workers-spot[count.index], "type")}"
+        instance_type = var.kube-workers-spot[count.index]["type"]
       }
 
       override {
-        instance_type = "${lookup(var.kube-workers-spot[count.index], "type_secondary")}"
+        instance_type = var.kube-workers-spot[count.index]["type_secondary"]
       }
     }
 
@@ -52,7 +55,7 @@ resource "aws_autoscaling_group" "spot" {
   tags = [
     {
       key                 = "Name"
-      value               = "kube-node-${var.name}-${var.env}-${lookup(var.kube-workers-spot[count.index], "kind")}-asg"
+      value               = "kube-node-${var.name}-${var.env}-${var.kube-workers-spot[count.index]["kind"]}-asg"
       propagate_at_launch = "true"
     },
     {
@@ -62,7 +65,7 @@ resource "aws_autoscaling_group" "spot" {
     },
     {
       key                 = "Type"
-      value               = "${lookup(var.kube-workers-spot[count.index], "kind")}"
+      value               = var.kube-workers-spot[count.index]["kind"]
       propagate_at_launch = "true"
     },
     {
@@ -72,18 +75,19 @@ resource "aws_autoscaling_group" "spot" {
     },
     {
       key                 = "KubernetesClusterAndType"
-      value               = "${lookup(var.kube-workers-spot[count.index], "kind")}-${var.name}-${var.env}"
+      value               = "${var.kube-workers-spot[count.index]["kind"]}-${var.name}-${var.env}"
       propagate_at_launch = "true"
     },
     {
-      key                 = "k8s.io/cluster-autoscaler/node-template/label/${var.node-role-tag-cluster-autoscaler}/${lookup(var.kube-workers-spot[count.index], "kind")}"
-      value               = ""
+      key                 = "k8s.io/cluster-autoscaler/node-template/label/${var.node-role-tag-cluster-autoscaler}/${var.kube-workers-spot[count.index]["kind"]}"
+      value               = "ignored"
       propagate_at_launch = "true"
     },
   ]
 
   lifecycle {
     create_before_destroy = true
-    ignore_changes = ["desired_capacity"]
+    ignore_changes        = [desired_capacity]
   }
 }
+

--- a/modules/aws-kubernetes/kube-worker-spot.tf
+++ b/modules/aws-kubernetes/kube-worker-spot.tf
@@ -8,6 +8,13 @@ resource "aws_launch_template" "spot" {
     count.index,
   )
 
+  block_device_mappings {
+    device_name = "/dev/sda1"
+    ebs {
+      volume_size = var.kube-workers-spot[count.index]["disk"]
+    }
+  }
+
   iam_instance_profile {
     name = aws_iam_instance_profile.main.name
   }

--- a/modules/aws-kubernetes/kube-worker.tf
+++ b/modules/aws-kubernetes/kube-worker.tf
@@ -94,3 +94,22 @@ data "aws_autoscaling_groups" "infra" {
   }
 }
 
+resource "aws_autoscaling_schedule" "workers_morning_start" {
+  count                  = var.enable_weekday_workers_shutdown ? length(var.kube-workers) : 0
+  scheduled_action_name  = "Morning-Start-Schedule"
+  min_size               = var.kube-workers[count.index][min]
+  max_size               = var.kube-workers[count.index][max]
+  desired_capacity       = var.kube-workers[count.index][desired]
+  recurrence             = "0 5 * * 1-5"
+  autoscaling_group_name = "${element(aws_autoscaling_group.main.*.name, count.index)}"
+}
+
+resource "aws_autoscaling_schedule" "workers_afternoon_stop" {
+  count                  = var.enable_weekday_workers_shutdown ? length(var.kube-workers-spot) : 0
+  scheduled_action_name  = "Afternoon-Stop-Schedule"
+  min_size               = 0
+  max_size               = 0
+  desired_capacity       = 0
+  recurrence             = "45 23 * * *"
+  autoscaling_group_name = "${element(aws_autoscaling_group.main.*.name, count.index)}"
+}

--- a/modules/aws-kubernetes/kube-worker.tf
+++ b/modules/aws-kubernetes/kube-worker.tf
@@ -70,18 +70,6 @@ resource "aws_autoscaling_group" "main" {
   }
 }
 
-data "aws_instances" "main" {
-  count = length(var.kube-workers)
-
-  filter {
-    name   = "tag:aws:autoscaling:groupName"
-    values = [element(aws_autoscaling_group.main.*.id, count.index)]
-  }
-
-  instance_state_names = ["running"]
-  depends_on           = [aws_autoscaling_group.main]
-}
-
 data "aws_autoscaling_groups" "infra" {
   filter {
     name   = "key"

--- a/modules/aws-kubernetes/kube-worker.tf
+++ b/modules/aws-kubernetes/kube-worker.tf
@@ -12,7 +12,7 @@ resource "aws_launch_configuration" "main" {
 
   root_block_device {
     volume_type           = "gp2"
-    volume_size           = var.kube-worker[count.index]["disk"]
+    volume_size           = var.kube-workers[count.index]["disk"]
     delete_on_termination = "true"
   }
 
@@ -85,11 +85,11 @@ data "aws_autoscaling_groups" "infra" {
 resource "aws_autoscaling_schedule" "workers_morning_start" {
   count                  = var.enable_weekday_workers_shutdown ? length(var.kube-workers) : 0
   scheduled_action_name  = "Morning-Start-Schedule"
-  min_size               = var.kube-workers[count.index][min]
-  max_size               = var.kube-workers[count.index][max]
-  desired_capacity       = var.kube-workers[count.index][desired]
+  min_size               = var.kube-workers[count.index]["min"]
+  max_size               = var.kube-workers[count.index]["max"]
+  desired_capacity       = var.kube-workers[count.index]["desired"]
   recurrence             = "0 5 * * 1-5"
-  autoscaling_group_name = "${element(aws_autoscaling_group.main.*.name, count.index)}"
+  autoscaling_group_name = element(aws_autoscaling_group.main.*.name, count.index)
 }
 
 resource "aws_autoscaling_schedule" "workers_afternoon_stop" {
@@ -99,5 +99,5 @@ resource "aws_autoscaling_schedule" "workers_afternoon_stop" {
   max_size               = 0
   desired_capacity       = 0
   recurrence             = "45 23 * * *"
-  autoscaling_group_name = "${element(aws_autoscaling_group.main.*.name, count.index)}"
+  autoscaling_group_name = element(aws_autoscaling_group.main.*.name, count.index)
 }

--- a/modules/aws-kubernetes/kube-worker.tf
+++ b/modules/aws-kubernetes/kube-worker.tf
@@ -12,7 +12,7 @@ resource "aws_launch_configuration" "main" {
 
   root_block_device {
     volume_type           = "gp2"
-    volume_size           = "80"
+    volume_size           = var.kube-worker[count.index]["disk"]
     delete_on_termination = "true"
   }
 

--- a/modules/aws-kubernetes/kube-worker.tf
+++ b/modules/aws-kubernetes/kube-worker.tf
@@ -1,11 +1,14 @@
 resource "aws_launch_configuration" "main" {
-  count                = "${length(var.kube-workers)}"
-  name_prefix          = "${var.name}-${var.env}-k8s-${lookup(var.kube-workers[count.index], "kind")}-nodes"
-  image_id             = "${element(data.aws_ami.worker.*.id, count.index)}"
-  instance_type        = "${lookup(var.kube-workers[count.index], "type")}"
-  user_data            = "${element(data.template_cloudinit_config.config_worker.*.rendered, count.index)}"
-  iam_instance_profile = "${aws_iam_instance_profile.main.name}"
-  security_groups      = ["${aws_security_group.kubernetes-nodes.id}"]
+  count         = length(var.kube-workers)
+  name_prefix   = "${var.name}-${var.env}-k8s-${var.kube-workers[count.index]["kind"]}-nodes"
+  image_id      = element(data.aws_ami.worker.*.id, count.index)
+  instance_type = var.kube-workers[count.index]["type"]
+  user_data = element(
+    data.template_cloudinit_config.config_worker.*.rendered,
+    count.index,
+  )
+  iam_instance_profile = aws_iam_instance_profile.main.name
+  security_groups      = [aws_security_group.kubernetes-nodes.id]
 
   root_block_device {
     volume_type           = "gp2"
@@ -19,19 +22,19 @@ resource "aws_launch_configuration" "main" {
 }
 
 resource "aws_autoscaling_group" "main" {
-  count                = "${length(var.kube-workers)}"
-  name                 = "${var.name}-${var.env}-k8s-${lookup(var.kube-workers[count.index], "kind")}-asg"
-  vpc_zone_identifier  = ["${flatten(data.aws_subnet.private.*.id)}"]
-  desired_capacity     = "${lookup(var.kube-workers[count.index], "desired")}"
-  max_size             = "${lookup(var.kube-workers[count.index], "max")}"
-  min_size             = "${lookup(var.kube-workers[count.index], "min")}"
-  launch_configuration = "${element(aws_launch_configuration.main.*.name, count.index)}"
+  count                = length(var.kube-workers)
+  name                 = "${var.name}-${var.env}-k8s-${var.kube-workers[count.index]["kind"]}-asg"
+  vpc_zone_identifier  = data.aws_subnet.private.*.id
+  desired_capacity     = var.kube-workers[count.index]["desired"]
+  max_size             = var.kube-workers[count.index]["max"]
+  min_size             = var.kube-workers[count.index]["min"]
+  launch_configuration = element(aws_launch_configuration.main.*.name, count.index)
   termination_policies = ["OldestInstance"]
 
   tags = [
     {
       key                 = "Name"
-      value               = "kube-node-${var.name}-${var.env}-${lookup(var.kube-workers[count.index], "kind")}-asg"
+      value               = "kube-node-${var.name}-${var.env}-${var.kube-workers[count.index]["kind"]}-asg"
       propagate_at_launch = "true"
     },
     {
@@ -41,7 +44,7 @@ resource "aws_autoscaling_group" "main" {
     },
     {
       key                 = "Type"
-      value               = "${lookup(var.kube-workers[count.index], "kind")}"
+      value               = var.kube-workers[count.index]["kind"]
       propagate_at_launch = "true"
     },
     {
@@ -51,32 +54,32 @@ resource "aws_autoscaling_group" "main" {
     },
     {
       key                 = "KubernetesClusterAndType"
-      value               = "${lookup(var.kube-workers[count.index], "kind")}-${var.name}-${var.env}"
+      value               = "${var.kube-workers[count.index]["kind"]}-${var.name}-${var.env}"
       propagate_at_launch = "true"
     },
     {
-      key                 = "k8s.io/cluster-autoscaler/node-template/label/${var.node-role-tag-cluster-autoscaler}/${lookup(var.kube-workers[count.index], "kind")}"
-      value               = ""
+      key                 = "k8s.io/cluster-autoscaler/node-template/label/${var.node-role-tag-cluster-autoscaler}/${var.kube-workers[count.index]["kind"]}"
+      value               = "ignored"
       propagate_at_launch = "true"
     },
   ]
 
   lifecycle {
     create_before_destroy = true
-    ignore_changes = ["desired_capacity"]
+    ignore_changes        = [desired_capacity]
   }
 }
 
 data "aws_instances" "main" {
-  count = "${length(var.kube-workers)}"
+  count = length(var.kube-workers)
 
   filter {
     name   = "tag:aws:autoscaling:groupName"
-    values = ["${element(aws_autoscaling_group.main.*.id, count.index)}"]
+    values = [element(aws_autoscaling_group.main.*.id, count.index)]
   }
 
   instance_state_names = ["running"]
-  depends_on           = ["aws_autoscaling_group.main"]
+  depends_on           = [aws_autoscaling_group.main]
 }
 
 data "aws_autoscaling_groups" "infra" {
@@ -90,3 +93,4 @@ data "aws_autoscaling_groups" "infra" {
     values = ["infra-${var.name}-${var.env}"]
   }
 }
+

--- a/modules/aws-kubernetes/lb_app_internal.tf
+++ b/modules/aws-kubernetes/lb_app_internal.tf
@@ -2,20 +2,20 @@ resource "aws_lb" "internal-http" {
   name                             = "${var.name}-${var.env}-int-http"
   internal                         = true
   load_balancer_type               = "application"
-  subnets                          = ["${flatten(data.aws_subnet.public.*.id)}"]
-  security_groups                  = ["${aws_security_group.k8s-nodes.id}"]
+  subnets                          = data.aws_subnet.public.*.id
+  security_groups                  = [aws_security_group.k8s-nodes.id]
   enable_deletion_protection       = false
   enable_cross_zone_load_balancing = false
   idle_timeout                     = 400
 
-  tags {
+  tags = {
     Name = "${var.name}-${var.env}-int-http"
-    env  = "${var.env}"
+    env  = var.env
   }
 }
 
 resource "aws_lb_listener" "k8s-nodes-http-internal" {
-  load_balancer_arn = "${aws_lb.internal-http.arn}"
+  load_balancer_arn = aws_lb.internal-http.arn
   port              = "80"
   protocol          = "HTTP"
 
@@ -31,39 +31,46 @@ resource "aws_lb_listener" "k8s-nodes-http-internal" {
 }
 
 data "aws_acm_certificate" "internal" {
-  count       = "${length(var.kube-lb-internal-additional-domains)}"
-  domain      = "${element(formatlist("%s.%s", var.kube-lb-internal-additional-domains, replace(data.aws_route53_zone.additional.0.name, "/[.]$/", "")), count.index)}"
+  count = length(var.kube-lb-internal-additional-domains)
+  domain = element(
+    formatlist(
+      "%s.%s",
+      var.kube-lb-internal-additional-domains,
+      replace(data.aws_route53_zone.additional[0].name, "/[.]$/", ""),
+    ),
+    count.index,
+  )
   statuses    = ["ISSUED"]
   most_recent = true
 }
 
 resource "aws_lb_listener" "k8s-nodes-https-internal" {
-  count             = "${length(var.kube-lb-internal-additional-domains) > 0 ? 1 : 0}"
-  load_balancer_arn = "${aws_lb.internal-http.arn}"
+  count             = length(var.kube-lb-internal-additional-domains) > 0 ? 1 : 0
+  load_balancer_arn = aws_lb.internal-http.arn
   port              = "443"
   protocol          = "HTTPS"
 
   // https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html
   ssl_policy      = "ELBSecurityPolicy-TLS-1-2-2017-01"
-  certificate_arn = "${element(data.aws_acm_certificate.internal.*.arn, 0)}"
+  certificate_arn = element(data.aws_acm_certificate.internal.*.arn, 0)
 
   default_action {
     type             = "forward"
-    target_group_arn = "${aws_lb_target_group.k8s-nodes-internal.arn}"
+    target_group_arn = aws_lb_target_group.k8s-nodes-internal.arn
   }
 }
 
 resource "aws_lb_listener_certificate" "internal-http" {
-  count           = "${length(var.kube-lb-internal-additional-domains) == 0 ? 0 : length(var.kube-lb-internal-additional-domains) - 1}"
-  listener_arn    = "${aws_lb_listener.k8s-nodes-https-internal.arn}"
-  certificate_arn = "${element(data.aws_acm_certificate.internal.*.arn, count.index + 1)}"
+  count           = length(var.kube-lb-internal-additional-domains) == 0 ? 0 : length(var.kube-lb-internal-additional-domains) - 1
+  listener_arn    = aws_lb_listener.k8s-nodes-https-internal[0].arn
+  certificate_arn = element(data.aws_acm_certificate.internal.*.arn, count.index + 1)
 }
 
 resource "aws_lb_target_group" "k8s-nodes-internal" {
   name        = "${var.name}-${var.env}-k8s-nodes-int"
   port        = 32080
   protocol    = "HTTP"
-  vpc_id      = "${data.aws_subnet.public.0.vpc_id}"
+  vpc_id      = data.aws_subnet.public[0].vpc_id
   target_type = "instance"
 
   health_check {
@@ -77,20 +84,21 @@ resource "aws_lb_target_group" "k8s-nodes-internal" {
 }
 
 resource "aws_autoscaling_attachment" "k8s-nodes-internal" {
-  count                  = "${length(data.aws_autoscaling_groups.infra.names)}"
-  autoscaling_group_name = "${element(data.aws_autoscaling_groups.infra.names, count.index)}"
-  alb_target_group_arn   = "${aws_lb_target_group.k8s-nodes-internal.arn}"
+  count                  = length(data.aws_autoscaling_groups.infra.names)
+  autoscaling_group_name = element(data.aws_autoscaling_groups.infra.names, count.index)
+  alb_target_group_arn   = aws_lb_target_group.k8s-nodes-internal.arn
 }
 
 resource "aws_route53_record" "additional" {
-  count   = "${length(var.kube-lb-internal-additional-domains)}"
-  zone_id = "${var.additional-domain}"
-  name    = "${element(var.kube-lb-internal-additional-domains, count.index)}"
+  count   = length(var.kube-lb-internal-additional-domains)
+  zone_id = var.additional-domain
+  name    = element(var.kube-lb-internal-additional-domains, count.index)
   type    = "A"
 
   alias {
-    name                   = "${aws_lb.internal-http.dns_name}"
-    zone_id                = "${aws_lb.internal-http.zone_id}"
+    name                   = aws_lb.internal-http.dns_name
+    zone_id                = aws_lb.internal-http.zone_id
     evaluate_target_health = true
   }
 }
+

--- a/modules/aws-kubernetes/lb_external.tf
+++ b/modules/aws-kubernetes/lb_external.tf
@@ -1,36 +1,26 @@
-locals {
-  access_log = {
-    enabled = [
-      {
-        bucket  = "${var.name}-${var.env}-external-lb-logs"
-        enabled = true
-      },
-    ]
-
-    disabled = []
-  }
-}
-
 resource "aws_lb" "external" {
   name                             = "${var.name}-${var.env}-external"
   internal                         = false
   load_balancer_type               = "application"
-  subnets                          = ["${flatten(data.aws_subnet.public.*.id)}"]
-  security_groups                  = ["${aws_security_group.k8s-nodes.id}"]
+  subnets                          = flatten(data.aws_subnet.public.*.id)
+  security_groups                  = [aws_security_group.k8s-nodes.id]
   enable_deletion_protection       = false
   enable_cross_zone_load_balancing = false
   idle_timeout                     = 400
 
-  access_logs = ["${local.access_log[var.kube-lb-external-enable-access-log ? "enabled" : "disabled"]}"]
+  access_logs {
+    bucket  = "${var.name}-${var.env}-external-lb-logs"
+    enabled = var.kube-lb-external-enable-access-log
+  }
 
-  tags {
+  tags = {
     Name = "${var.name}-${var.env}-external"
-    env  = "${var.env}"
+    env  = var.env
   }
 }
 
 resource "aws_lb_listener" "k8s-nodes-http" {
-  load_balancer_arn = "${aws_lb.external.arn}"
+  load_balancer_arn = aws_lb.external.arn
   port              = "80"
   protocol          = "HTTP"
 
@@ -46,30 +36,30 @@ resource "aws_lb_listener" "k8s-nodes-http" {
 }
 
 resource "aws_lb_listener" "k8s-nodes-https" {
-  count             = "${length(var.kube-lb-external-domains) > 0 ? 1 : 0}"
-  load_balancer_arn = "${aws_lb.external.arn}"
+  count             = length(var.kube-lb-external-domains) > 0 ? 1 : 0
+  load_balancer_arn = aws_lb.external.arn
   port              = "443"
   protocol          = "HTTPS"
 
   // https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html
   ssl_policy      = "ELBSecurityPolicy-TLS-1-2-2017-01"
-  certificate_arn = "${element(data.aws_acm_certificate.main.*.arn, 0)}"
+  certificate_arn = element(data.aws_acm_certificate.main.*.arn, 0)
 
   default_action {
     type             = "forward"
-    target_group_arn = "${aws_lb_target_group.k8s-nodes.arn}"
+    target_group_arn = aws_lb_target_group.k8s-nodes.arn
   }
 }
 
 resource "aws_lb_listener_certificate" "main" {
-  count           = "${length(var.kube-lb-external-domains) == 0 ? 0 : length(var.kube-lb-external-domains) - 1}"
-  listener_arn    = "${aws_lb_listener.k8s-nodes-https.arn}"
-  certificate_arn = "${element(data.aws_acm_certificate.main.*.arn, count.index + 1)}"
+  count           = length(var.kube-lb-external-domains) == 0 ? 0 : length(var.kube-lb-external-domains) - 1
+  listener_arn    = aws_lb_listener.k8s-nodes-https[0].arn
+  certificate_arn = element(data.aws_acm_certificate.main.*.arn, count.index + 1)
 }
 
 data "aws_acm_certificate" "main" {
-  count       = "${length(var.kube-lb-external-domains)}"
-  domain      = "${element(var.kube-lb-external-domains, count.index)}"
+  count       = length(var.kube-lb-external-domains)
+  domain      = element(var.kube-lb-external-domains, count.index)
   statuses    = ["ISSUED"]
   most_recent = true
 }
@@ -78,7 +68,7 @@ resource "aws_lb_target_group" "k8s-nodes" {
   name        = "${var.name}-${var.env}-k8s-nodes"
   port        = 31080
   protocol    = "HTTP"
-  vpc_id      = "${data.aws_subnet.public.0.vpc_id}"
+  vpc_id      = data.aws_subnet.public[0].vpc_id
   target_type = "instance"
 
   health_check {
@@ -92,16 +82,16 @@ resource "aws_lb_target_group" "k8s-nodes" {
 }
 
 resource "aws_autoscaling_attachment" "k8s-nodes" {
-  count                  = "${length(data.aws_autoscaling_groups.infra.names)}"
-  autoscaling_group_name = "${element(data.aws_autoscaling_groups.infra.names, count.index)}"
-  alb_target_group_arn   = "${aws_lb_target_group.k8s-nodes.arn}"
+  count                  = length(data.aws_autoscaling_groups.infra.names)
+  autoscaling_group_name = element(data.aws_autoscaling_groups.infra.names, count.index)
+  alb_target_group_arn   = aws_lb_target_group.k8s-nodes.arn
 }
 
 resource "aws_security_group" "k8s-nodes" {
   name   = "${var.name}-${var.env}-external-lb"
-  vpc_id = "${data.aws_subnet.public.0.vpc_id}"
+  vpc_id = data.aws_subnet.public[0].vpc_id
 
-  tags {
+  tags = {
     Name = "${var.name}-${var.env}-external-lb"
   }
 
@@ -127,3 +117,4 @@ resource "aws_security_group" "k8s-nodes" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 }
+

--- a/modules/aws-kubernetes/lb_net_internal.tf
+++ b/modules/aws-kubernetes/lb_net_internal.tf
@@ -2,14 +2,14 @@ resource "aws_lb" "internal" {
   name                             = "${var.name}-${var.env}-int"
   internal                         = true
   load_balancer_type               = "network"
-  subnets                          = ["${flatten(data.aws_subnet.public.*.id)}"]
+  subnets                          = data.aws_subnet.public.*.id
   enable_deletion_protection       = false
   enable_cross_zone_load_balancing = false
   idle_timeout                     = 400
 
-  tags {
+  tags = {
     Name        = "${var.name}-${var.env}-int"
-    Environment = "${var.env}"
+    Environment = var.env
   }
 }
 
@@ -17,7 +17,7 @@ resource "aws_lb_target_group" "k8s-master" {
   name        = "${var.name}-${var.env}-k8s-master"
   port        = 6443
   protocol    = "TCP"
-  vpc_id      = "${data.aws_subnet.public.0.vpc_id}"
+  vpc_id      = data.aws_subnet.public[0].vpc_id
   target_type = "ip"
 
   health_check {
@@ -30,27 +30,27 @@ resource "aws_lb_target_group" "k8s-master" {
 }
 
 resource "aws_lb_listener" "k8s-master" {
-  load_balancer_arn = "${aws_lb.internal.arn}"
+  load_balancer_arn = aws_lb.internal.arn
   port              = 6443
   protocol          = "TCP"
 
   default_action {
     type             = "forward"
-    target_group_arn = "${aws_lb_target_group.k8s-master.arn}"
+    target_group_arn = aws_lb_target_group.k8s-master.arn
   }
 }
 
 resource "aws_lb_target_group_attachment" "k8s-master" {
-  count            = "${var.kube-master-count}"
-  target_group_arn = "${aws_lb_target_group.k8s-master.arn}"
-  target_id        = "${element(aws_instance.k8s-master.*.private_ip, count.index)}"
+  count            = var.kube-master-count
+  target_group_arn = aws_lb_target_group.k8s-master.arn
+  target_id        = element(aws_instance.k8s-master.*.private_ip, count.index)
 }
 
 resource "aws_lb_target_group" "internal-ingress" {
   name        = "${var.name}-${var.env}-int-ingress"
   port        = 32080
   protocol    = "TCP"
-  vpc_id      = "${data.aws_subnet.public.0.vpc_id}"
+  vpc_id      = data.aws_subnet.public[0].vpc_id
   target_type = "instance"
 
   health_check {
@@ -63,55 +63,56 @@ resource "aws_lb_target_group" "internal-ingress" {
 }
 
 resource "aws_lb_listener" "internal-ingress" {
-  load_balancer_arn = "${aws_lb.internal.arn}"
+  load_balancer_arn = aws_lb.internal.arn
   port              = "80"
   protocol          = "TCP"
 
   default_action {
     type             = "forward"
-    target_group_arn = "${aws_lb_target_group.internal-ingress.arn}"
+    target_group_arn = aws_lb_target_group.internal-ingress.arn
   }
 }
 
 resource "aws_autoscaling_attachment" "internal-ingress" {
-  count                  = "${length(data.aws_autoscaling_groups.infra.names)}"
-  autoscaling_group_name = "${element(data.aws_autoscaling_groups.infra.names, count.index)}"
-  alb_target_group_arn   = "${aws_lb_target_group.internal-ingress.arn}"
+  count                  = length(data.aws_autoscaling_groups.infra.names)
+  autoscaling_group_name = element(data.aws_autoscaling_groups.infra.names, count.index)
+  alb_target_group_arn   = aws_lb_target_group.internal-ingress.arn
 }
 
 resource "aws_route53_record" "master-lb" {
-  zone_id = "${var.kube-domain}"
+  zone_id = var.kube-domain
   name    = "master"
   type    = "A"
 
   alias {
-    name                   = "${aws_lb.internal.dns_name}"
-    zone_id                = "${aws_lb.internal.zone_id}"
+    name                   = aws_lb.internal.dns_name
+    zone_id                = aws_lb.internal.zone_id
     evaluate_target_health = true
   }
 }
 
 resource "aws_route53_record" "internal" {
-  count   = "${length(var.kube-lb-internal-domains)}"
-  zone_id = "${var.kube-domain}"
-  name    = "${element(var.kube-lb-internal-domains, count.index)}"
+  count   = length(var.kube-lb-internal-domains)
+  zone_id = var.kube-domain
+  name    = element(var.kube-lb-internal-domains, count.index)
   type    = "A"
 
   alias {
-    name                   = "${aws_lb.internal.dns_name}"
-    zone_id                = "${aws_lb.internal.zone_id}"
+    name                   = aws_lb.internal.dns_name
+    zone_id                = aws_lb.internal.zone_id
     evaluate_target_health = true
   }
 }
 
 resource "aws_route53_record" "control-plane" {
-  zone_id = "${var.kube-domain}"
+  zone_id = var.kube-domain
   name    = "control-plane"
   type    = "A"
 
   alias {
-    name                   = "${aws_lb.internal.dns_name}"
-    zone_id                = "${aws_lb.internal.zone_id}"
+    name                   = aws_lb.internal.dns_name
+    zone_id                = aws_lb.internal.zone_id
     evaluate_target_health = true
   }
 }
+

--- a/modules/aws-kubernetes/output.tf
+++ b/modules/aws-kubernetes/output.tf
@@ -20,14 +20,8 @@ ${join(
   ),
   )}
 
-${join("\n", data.template_file.k8s-worker-node.*.rendered)}
-
 [gated:children]
 master
-${join("\n", data.template_file.k8s-worker-kind.*.rendered)}
-
-[nodes:children]
-${join("\n", data.template_file.k8s-worker-kind.*.rendered)}
 
 [all:vars]
 ansible_user=ubuntu
@@ -103,30 +97,6 @@ data "template_file" "k8s-master" {
 
   vars = {
     index = count.index
-  }
-}
-
-data "template_file" "k8s-worker-kind" {
-  count    = length(var.kube-workers)
-  template = "$${kind}"
-
-  vars = {
-    kind = var.kube-workers[count.index]["kind"]
-  }
-}
-
-data "template_file" "k8s-worker-node" {
-  count = length(data.aws_instances.main)
-
-  template = <<EOF
-[$${kind}]
-$${nodes}
-EOF
-
-
-  vars = {
-    kind  = var.kube-workers[count.index]["kind"]
-    nodes = join("\n", data.aws_instances.main[count.index].private_ips)
   }
 }
 

--- a/modules/aws-kubernetes/output.tf
+++ b/modules/aws-kubernetes/output.tf
@@ -73,11 +73,11 @@ output "internal-lb-dns-name" {
 }
 
 output "masters-security-group" {
-  value = "${aws_security_group.kubernetes-master.id}"
+  value = aws_security_group.kubernetes-master.id
 }
 
 output "nodes-security-group" {
-  value = "${aws_security_group.kubernetes-nodes.id}"
+  value = aws_security_group.kubernetes-nodes.id
 }
 
 data "template_file" "bastion" {

--- a/modules/aws-kubernetes/output.tf
+++ b/modules/aws-kubernetes/output.tf
@@ -1,10 +1,24 @@
 locals {
   inventory = <<EOF
 [bastion]
-${join("\n", formatlist("%s ansible_host=%s", data.template_file.bastion.*.rendered, var.kube-bastions))}
+${join(
+  "\n",
+  formatlist(
+    "%s ansible_host=%s",
+    data.template_file.bastion.*.rendered,
+    var.kube-bastions,
+  ),
+  )}
 
 [master]
-${join("\n", formatlist("%s ansible_host=%s", data.template_file.k8s-master.*.rendered, aws_instance.k8s-master.*.private_ip))}
+${join(
+  "\n",
+  formatlist(
+    "%s ansible_host=%s",
+    data.template_file.k8s-master.*.rendered,
+    aws_instance.k8s-master.*.private_ip,
+  ),
+  )}
 
 ${join("\n", data.template_file.k8s-worker-node.*.rendered)}
 
@@ -28,60 +42,70 @@ ansible_ssh_common_args='-o ProxyCommand="ssh -o StrictHostKeyChecking=no -W %h:
 public_lb_address=${aws_lb.external.dns_name}
 
 [master:vars]
-etcd_initial_cluster='${join(",", formatlist("%s=https://%s:2380", data.template_file.k8s-master.*.rendered, aws_route53_record.k8s-master.*.fqdn))}'
+etcd_initial_cluster='${join(
+  ",",
+  formatlist(
+    "%s=https://%s:2380",
+    data.template_file.k8s-master.*.rendered,
+    aws_route53_record.k8s-master.*.fqdn,
+  ),
+)}'
 control_plane_endpoint=${aws_route53_record.control-plane.fqdn}
 dns_zone=${join(".", compact(split(".", data.aws_route53_zone.main.name)))}
 
 EOF
+
 }
 
 output "inventory" {
-  value = "${local.inventory}"
+  value = local.inventory
 }
 
 output "external-lb-arn" {
-  value = "${aws_lb.external.arn}"
+  value = aws_lb.external.arn
 }
 
 data "template_file" "bastion" {
-  count = "${length(var.kube-bastions)}"
+  count = length(var.kube-bastions)
 
   template = "bastion-$${index}"
 
-  vars {
-    index = "${count.index}"
+  vars = {
+    index = count.index
   }
 }
 
 data "template_file" "k8s-master" {
-  count = "${var.kube-master-count}"
+  count = var.kube-master-count
 
   template = "master-$${index+1}"
 
-  vars {
-    index = "${count.index}"
+  vars = {
+    index = count.index
   }
 }
 
 data "template_file" "k8s-worker-kind" {
-  count    = "${length(var.kube-workers)}"
+  count    = length(var.kube-workers)
   template = "$${kind}"
 
-  vars {
-    kind = "${lookup(var.kube-workers[count.index], "kind")}"
+  vars = {
+    kind = var.kube-workers[count.index]["kind"]
   }
 }
 
 data "template_file" "k8s-worker-node" {
-  count = "${data.aws_instances.main.count}"
+  count = length(data.aws_instances.main)
 
   template = <<EOF
 [$${kind}]
 $${nodes}
 EOF
 
-  vars {
-    kind  = "${lookup(var.kube-workers[count.index], "kind")}"
-    nodes = "${join("\n", data.aws_instances.main.*.private_ips[count.index])}"
+
+  vars = {
+    kind  = var.kube-workers[count.index]["kind"]
+    nodes = join("\n", data.aws_instances.main[count.index].private_ips)
   }
 }
+

--- a/modules/aws-kubernetes/output.tf
+++ b/modules/aws-kubernetes/output.tf
@@ -52,6 +52,7 @@ etcd_initial_cluster='${join(
 )}'
 control_plane_endpoint=${aws_route53_record.control-plane.fqdn}
 dns_zone=${join(".", compact(split(".", data.aws_route53_zone.main.name)))}
+env=${var.env}
 
 EOF
 
@@ -63,6 +64,26 @@ output "inventory" {
 
 output "external-lb-arn" {
   value = aws_lb.external.arn
+}
+
+output "external-lb-dns-name" {
+  value = aws_lb.external.dns_name
+}
+
+output "internal-lb-arn" {
+  value = aws_lb.internal-http.arn
+}
+
+output "internal-lb-dns-name" {
+  value = aws_lb.internal-http.dns_name
+}
+
+output "masters-security-group" {
+  value = "${aws_security_group.kubernetes-master.id}"
+}
+
+output "nodes-security-group" {
+  value = "${aws_security_group.kubernetes-nodes.id}"
 }
 
 data "template_file" "bastion" {

--- a/modules/aws-kubernetes/s3.tf
+++ b/modules/aws-kubernetes/s3.tf
@@ -1,4 +1,5 @@
-data "aws_elb_service_account" "main" {}
+data "aws_elb_service_account" "main" {
+}
 
 data "aws_iam_policy_document" "main" {
   statement {
@@ -6,7 +7,7 @@ data "aws_iam_policy_document" "main" {
 
     principals {
       type        = "AWS"
-      identifiers = ["${data.aws_elb_service_account.main.arn}"]
+      identifiers = [data.aws_elb_service_account.main.arn]
     }
 
     effect = "Allow"
@@ -22,11 +23,11 @@ data "aws_iam_policy_document" "main" {
 }
 
 resource "aws_s3_bucket" "main" {
-  count  = "${var.kube-lb-external-enable-access-log ? 1 : 0}"
+  count  = var.kube-lb-external-enable-access-log ? 1 : 0
   bucket = "${var.name}-${var.env}-external-lb-logs"
   acl    = "log-delivery-write"
-  policy = "${data.aws_iam_policy_document.main.json}"
-  region = "${var.region}"
+  policy = data.aws_iam_policy_document.main.json
+  region = var.region
 
   lifecycle_rule {
     id      = "${var.name}-${var.env}-external-lb-logs"
@@ -49,8 +50,9 @@ resource "aws_s3_bucket" "main" {
     }
   }
 
-  tags {
+  tags = {
     Name        = "${var.name}-${var.env}-external-lb-logs"
-    Environment = "${var.env}"
+    Environment = var.env
   }
 }
+

--- a/modules/aws-kubernetes/sg.tf
+++ b/modules/aws-kubernetes/sg.tf
@@ -63,6 +63,15 @@ resource "aws_security_group_rule" "k8s-node-nginx-ingress" {
   security_group_id = aws_security_group.kubernetes-nodes.id
 }
 
+resource "aws_security_group_rule" "k8s-node-calico-metrics" {
+  type              = "ingress"
+  from_port         = 9091
+  to_port           = 9091
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.kubernetes-nodes.id
+}
+
 resource "aws_security_group_rule" "k8s-node-node-exporter" {
   type              = "ingress"
   from_port         = 9100
@@ -118,21 +127,6 @@ resource "aws_security_group" "kubernetes-master" {
     Name = "k8s-master-${var.name}-${var.env}"
     Env  = var.env
   }
-  #  //sg for  kubernetes
-  #  ingress {
-  #    from_port   = 31000
-  #    to_port     = 31000
-  #    protocol    = "tcp"
-  #    cidr_blocks = ["0.0.0.0/0"]
-  #  }
-
-  #  //sg for kubernetes
-  #  ingress {
-  #    from_port   = 32000
-  #    to_port     = 32000
-  #    protocol    = "tcp"
-  #    cidr_blocks = ["0.0.0.0/0"]
-  #  }
 }
 
 resource "aws_security_group_rule" "k8s-master-ssh" {
@@ -212,6 +206,15 @@ resource "aws_security_group_rule" "k8s-master-node-exporter" {
   type              = "ingress"
   from_port         = 9100
   to_port           = 9100
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.kubernetes-master.id
+}
+
+resource "aws_security_group_rule" "k8s-master-calico-metrics" {
+  type              = "ingress"
+  from_port         = 9091
+  to_port           = 9091
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.kubernetes-master.id

--- a/modules/aws-kubernetes/sg.tf
+++ b/modules/aws-kubernetes/sg.tf
@@ -63,15 +63,6 @@ resource "aws_security_group_rule" "k8s-node-nginx-ingress" {
   security_group_id = aws_security_group.kubernetes-nodes.id
 }
 
-resource "aws_security_group_rule" "k8s-node-weave-net" {
-  type              = "ingress"
-  from_port         = 6781
-  to_port           = 6783
-  protocol          = "tcp"
-  cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = aws_security_group.kubernetes-nodes.id
-}
-
 resource "aws_security_group_rule" "k8s-node-node-exporter" {
   type              = "ingress"
   from_port         = 9100
@@ -193,15 +184,6 @@ resource "aws_security_group_rule" "k8s-master-etcd-metrics" {
   type              = "ingress"
   from_port         = 2378
   to_port           = 2378
-  protocol          = "tcp"
-  cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = aws_security_group.kubernetes-master.id
-}
-
-resource "aws_security_group_rule" "k8s-master-weave-net" {
-  type              = "ingress"
-  from_port         = 6781
-  to_port           = 6783
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.kubernetes-master.id

--- a/modules/aws-kubernetes/sg.tf
+++ b/modules/aws-kubernetes/sg.tf
@@ -1,11 +1,11 @@
 resource "aws_security_group" "kubernetes-nodes" {
   name        = "k8s-nodes-${var.name}-${var.env}"
   description = "Kubernetes nodes Security Group"
-  vpc_id      = "${data.aws_subnet.private.0.vpc_id}"
+  vpc_id      = data.aws_subnet.private[0].vpc_id
 
-  tags {
+  tags = {
     Name = "k8s-nodes-${var.name}-${var.env}"
-    Env  = "${var.env}"
+    Env  = var.env
   }
 }
 
@@ -15,7 +15,7 @@ resource "aws_security_group_rule" "k8s-node-ssh" {
   to_port           = 22
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.kubernetes-nodes.id}"
+  security_group_id = aws_security_group.kubernetes-nodes.id
 }
 
 resource "aws_security_group_rule" "k8s-node-BGP" {
@@ -24,7 +24,7 @@ resource "aws_security_group_rule" "k8s-node-BGP" {
   to_port           = 179
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.kubernetes-nodes.id}"
+  security_group_id = aws_security_group.kubernetes-nodes.id
 }
 
 resource "aws_security_group_rule" "k8s-node-IPP" {
@@ -33,7 +33,7 @@ resource "aws_security_group_rule" "k8s-node-IPP" {
   to_port           = 0
   protocol          = 94
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.kubernetes-nodes.id}"
+  security_group_id = aws_security_group.kubernetes-nodes.id
 }
 
 resource "aws_security_group_rule" "k8s-node-apiserver" {
@@ -42,7 +42,7 @@ resource "aws_security_group_rule" "k8s-node-apiserver" {
   to_port           = 10250
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.kubernetes-nodes.id}"
+  security_group_id = aws_security_group.kubernetes-nodes.id
 }
 
 resource "aws_security_group_rule" "k8s-node-nginx-ingress" {
@@ -51,7 +51,7 @@ resource "aws_security_group_rule" "k8s-node-nginx-ingress" {
   to_port           = 31080
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.kubernetes-nodes.id}"
+  security_group_id = aws_security_group.kubernetes-nodes.id
 }
 
 resource "aws_security_group_rule" "k8s-node-weave-net" {
@@ -60,7 +60,7 @@ resource "aws_security_group_rule" "k8s-node-weave-net" {
   to_port           = 6783
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.kubernetes-nodes.id}"
+  security_group_id = aws_security_group.kubernetes-nodes.id
 }
 
 resource "aws_security_group_rule" "k8s-node-node-exporter" {
@@ -69,7 +69,7 @@ resource "aws_security_group_rule" "k8s-node-node-exporter" {
   to_port           = 9100
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.kubernetes-nodes.id}"
+  security_group_id = aws_security_group.kubernetes-nodes.id
 }
 
 resource "aws_security_group_rule" "k8s-node-kubelet" {
@@ -78,7 +78,7 @@ resource "aws_security_group_rule" "k8s-node-kubelet" {
   to_port           = 10255
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.kubernetes-nodes.id}"
+  security_group_id = aws_security_group.kubernetes-nodes.id
 }
 
 resource "aws_security_group_rule" "k8s-node-cadvisor" {
@@ -87,7 +87,7 @@ resource "aws_security_group_rule" "k8s-node-cadvisor" {
   to_port           = 10248
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.kubernetes-nodes.id}"
+  security_group_id = aws_security_group.kubernetes-nodes.id
 }
 
 resource "aws_security_group_rule" "k8s-node-all" {
@@ -96,29 +96,28 @@ resource "aws_security_group_rule" "k8s-node-all" {
   to_port           = 0
   protocol          = "-1"
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.kubernetes-nodes.id}"
+  security_group_id = aws_security_group.kubernetes-nodes.id
 }
 
 resource "aws_security_group_rule" "k8s-nodes-sg-rules" {
-  count             = "${length(var.kube-workers-security-group)}"
-  type              = "${lookup(var.kube-workers-security-group[count.index], "type")}"
-  from_port         = "${lookup(var.kube-workers-security-group[count.index], "from_port")}"
-  to_port           = "${lookup(var.kube-workers-security-group[count.index], "to_port")}"
-  protocol          = "${lookup(var.kube-workers-security-group[count.index], "protocol")}"
-  cidr_blocks       = ["${lookup(var.kube-workers-security-group[count.index], "cidr_blocks")}"]
-  security_group_id = "${aws_security_group.kubernetes-nodes.id}"
+  count             = length(var.kube-workers-security-group)
+  type              = var.kube-workers-security-group[count.index]["type"]
+  from_port         = var.kube-workers-security-group[count.index]["from_port"]
+  to_port           = var.kube-workers-security-group[count.index]["to_port"]
+  protocol          = var.kube-workers-security-group[count.index]["protocol"]
+  cidr_blocks       = [var.kube-workers-security-group[count.index]["cidr_blocks"]]
+  security_group_id = aws_security_group.kubernetes-nodes.id
 }
 
 resource "aws_security_group" "kubernetes-master" {
   name        = "k8s-master-${var.name}-${var.env}"
   description = "Kubernetes master Security Group"
-  vpc_id      = "${data.aws_subnet.private.0.vpc_id}"
+  vpc_id      = data.aws_subnet.private[0].vpc_id
 
-  tags {
+  tags = {
     Name = "k8s-master-${var.name}-${var.env}"
-    Env  = "${var.env}"
+    Env  = var.env
   }
-
   #  //sg for  kubernetes
   #  ingress {
   #    from_port   = 31000
@@ -142,7 +141,7 @@ resource "aws_security_group_rule" "k8s-master-ssh" {
   to_port           = 22
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.kubernetes-master.id}"
+  security_group_id = aws_security_group.kubernetes-master.id
 }
 
 resource "aws_security_group_rule" "k8s-master-BGP" {
@@ -151,7 +150,7 @@ resource "aws_security_group_rule" "k8s-master-BGP" {
   to_port           = 179
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.kubernetes-master.id}"
+  security_group_id = aws_security_group.kubernetes-master.id
 }
 
 resource "aws_security_group_rule" "k8s-master-IPP" {
@@ -160,7 +159,7 @@ resource "aws_security_group_rule" "k8s-master-IPP" {
   to_port           = 0
   protocol          = 94
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.kubernetes-master.id}"
+  security_group_id = aws_security_group.kubernetes-master.id
 }
 
 resource "aws_security_group_rule" "k8s-master-apiserver" {
@@ -169,7 +168,7 @@ resource "aws_security_group_rule" "k8s-master-apiserver" {
   to_port           = 6443
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.kubernetes-master.id}"
+  security_group_id = aws_security_group.kubernetes-master.id
 }
 
 resource "aws_security_group_rule" "k8s-master-etcd-peers" {
@@ -178,7 +177,7 @@ resource "aws_security_group_rule" "k8s-master-etcd-peers" {
   to_port           = 2380
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.kubernetes-master.id}"
+  security_group_id = aws_security_group.kubernetes-master.id
 }
 
 resource "aws_security_group_rule" "k8s-master-etcd-metrics" {
@@ -187,7 +186,7 @@ resource "aws_security_group_rule" "k8s-master-etcd-metrics" {
   to_port           = 2378
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.kubernetes-master.id}"
+  security_group_id = aws_security_group.kubernetes-master.id
 }
 
 resource "aws_security_group_rule" "k8s-master-weave-net" {
@@ -196,7 +195,7 @@ resource "aws_security_group_rule" "k8s-master-weave-net" {
   to_port           = 6783
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.kubernetes-master.id}"
+  security_group_id = aws_security_group.kubernetes-master.id
 }
 
 //sg for apiserver kubelet, controller manager metrics, scheduler metrics
@@ -206,7 +205,7 @@ resource "aws_security_group_rule" "k8s-master-metrics" {
   to_port           = 10252
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.kubernetes-master.id}"
+  security_group_id = aws_security_group.kubernetes-master.id
 }
 
 resource "aws_security_group_rule" "k8s-master-kubelet" {
@@ -215,7 +214,7 @@ resource "aws_security_group_rule" "k8s-master-kubelet" {
   to_port           = 10255
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.kubernetes-master.id}"
+  security_group_id = aws_security_group.kubernetes-master.id
 }
 
 resource "aws_security_group_rule" "k8s-master-node-exporter" {
@@ -224,7 +223,7 @@ resource "aws_security_group_rule" "k8s-master-node-exporter" {
   to_port           = 9100
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.kubernetes-master.id}"
+  security_group_id = aws_security_group.kubernetes-master.id
 }
 
 resource "aws_security_group_rule" "k8s-master-all" {
@@ -233,15 +232,16 @@ resource "aws_security_group_rule" "k8s-master-all" {
   to_port           = 0
   protocol          = "-1"
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.kubernetes-master.id}"
+  security_group_id = aws_security_group.kubernetes-master.id
 }
 
 resource "aws_security_group_rule" "k8s-master-sg-rules" {
-  count             = "${length(var.kube-master-security-group)}"
-  type              = "${lookup(var.kube-master-security-group[count.index], "type")}"
-  from_port         = "${lookup(var.kube-master-security-group[count.index], "from_port")}"
-  to_port           = "${lookup(var.kube-master-security-group[count.index], "to_port")}"
-  protocol          = "${lookup(var.kube-master-security-group[count.index], "protocol")}"
-  cidr_blocks       = ["${lookup(var.kube-master-security-group[count.index], "cidr_blocks")}"]
-  security_group_id = "${aws_security_group.kubernetes-master.id}"
+  count             = length(var.kube-master-security-group)
+  type              = var.kube-master-security-group[count.index]["type"]
+  from_port         = var.kube-master-security-group[count.index]["from_port"]
+  to_port           = var.kube-master-security-group[count.index]["to_port"]
+  protocol          = var.kube-master-security-group[count.index]["protocol"]
+  cidr_blocks       = [var.kube-master-security-group[count.index]["cidr_blocks"]]
+  security_group_id = aws_security_group.kubernetes-master.id
 }
+

--- a/modules/aws-kubernetes/sg.tf
+++ b/modules/aws-kubernetes/sg.tf
@@ -13,7 +13,7 @@ resource "aws_security_group" "kubernetes-nodes" {
     local.sg_tags,
     map(
       "Name", "k8s-nodes-${var.name}-${var.env}",
-      "Env", "${var.env}",
+      "Env", var.env,
     )
   )
 }

--- a/modules/aws-kubernetes/sg.tf
+++ b/modules/aws-kubernetes/sg.tf
@@ -1,12 +1,21 @@
+locals {
+  sg_tags = map(
+    "kubernetes.io/cluster/${var.name}-${var.env}", "owned",
+  )
+}
+
 resource "aws_security_group" "kubernetes-nodes" {
   name        = "k8s-nodes-${var.name}-${var.env}"
   description = "Kubernetes nodes Security Group"
   vpc_id      = data.aws_subnet.private[0].vpc_id
 
-  tags = {
-    Name = "k8s-nodes-${var.name}-${var.env}"
-    Env  = var.env
-  }
+  tags = merge(
+    local.sg_tags,
+    map(
+      "Name", "k8s-nodes-${var.name}-${var.env}",
+      "Env", "${var.env}",
+    )
+  )
 }
 
 resource "aws_security_group_rule" "k8s-node-ssh" {

--- a/modules/aws-kubernetes/versions.tf
+++ b/modules/aws-kubernetes/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_version = "~> 0.12"
+  required_providers {
+    aws      = "~> 2.65"
+    template = "~> 2.1"
+  }
+}

--- a/modules/aws-kubernetes/versions.tf
+++ b/modules/aws-kubernetes/versions.tf
@@ -1,7 +1,13 @@
 terraform {
-  required_version = "~> 0.12"
+  required_version = ">= 0.13"
   required_providers {
-    aws      = "~> 2.65"
-    template = "~> 2.1"
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 2.65"
+    }
+    template = {
+      source  = "hashicorp/template"
+      version = "~> 2.1"
+    }
   }
 }

--- a/modules/aws-vpc/bastion.tf
+++ b/modules/aws-vpc/bastion.tf
@@ -1,91 +1,91 @@
 resource "aws_instance" "bastion" {
-  count                       = "${var.bastion-count}"
-  ami                         = "${data.aws_ami.main.id}"
-  instance_type               = "${var.bastion-instance-type}"
-  user_data                   = "${data.template_cloudinit_config.config.rendered}"
-  subnet_id                   = "${element(aws_subnet.public.*.id, count.index)}"
+  count                       = var.bastion-count
+  ami                         = data.aws_ami.main.id
+  instance_type               = var.bastion-instance-type
+  user_data                   = data.template_cloudinit_config.config.rendered
+  subnet_id                   = element(aws_subnet.public.*.id, count.index)
   associate_public_ip_address = true
-  vpc_security_group_ids      = ["${aws_security_group.bastion.id}"]
+  vpc_security_group_ids      = [aws_security_group.bastion.id]
 
   root_block_device {
     volume_type = "gp2"
     volume_size = 50
   }
 
-  tags {
+  tags = {
     Name = "bastion-${var.name}-${var.env}-${count.index+1}"
     Role = "bastion"
   }
 
   lifecycle {
-    ignore_changes = ["ami"]
+    ignore_changes = [ami]
   }
 }
 
 resource "aws_eip" "bastion" {
-  count      = "${var.bastion-count}"
-  depends_on = ["aws_internet_gateway.main"]
+  count      = var.bastion-count
+  depends_on = [aws_internet_gateway.main]
 
-  tags {
+  tags = {
     Name = "bastion-${var.name}-${var.env}-${count.index+1}"
   }
 }
 
 resource "aws_eip_association" "bastion" {
-  count         = "${var.bastion-count}"
-  instance_id   = "${element(aws_instance.bastion.*.id, count.index)}"
-  allocation_id = "${element(aws_eip.bastion.*.id, count.index)}"
+  count         = var.bastion-count
+  instance_id   = element(aws_instance.bastion.*.id, count.index)
+  allocation_id = element(aws_eip.bastion.*.id, count.index)
 }
 
 resource "aws_security_group" "bastion" {
   name   = "bastion-${var.env}"
-  vpc_id = "${aws_vpc.main.id}"
+  vpc_id = aws_vpc.main.id
 
-  tags {
+  tags = {
     Name = "bastion-${var.name}-${var.env}"
   }
 }
 
 resource "aws_security_group_rule" "egress" {
-  count       = "${var.bastion-ssh-enable}"
+  count       = var.bastion-ssh-enable ? 1 : 0
   type        = "egress"
   from_port   = 0
   to_port     = 0
   protocol    = "-1"
   cidr_blocks = ["0.0.0.0/0"]
 
-  security_group_id = "${aws_security_group.bastion.id}"
+  security_group_id = aws_security_group.bastion.id
 }
 
 resource "aws_security_group_rule" "ssh" {
-  count       = "${var.bastion-ssh-enable}"
+  count       = var.bastion-ssh-enable ? 1 : 0
   type        = "ingress"
   from_port   = 22
   to_port     = 22
   protocol    = "TCP"
   cidr_blocks = ["0.0.0.0/0"]
 
-  security_group_id = "${aws_security_group.bastion.id}"
+  security_group_id = aws_security_group.bastion.id
 }
 
 resource "aws_security_group_rule" "vpn-tcp" {
-  count       = "${var.bastion-vpn-enable}"
+  count       = var.bastion-vpn-enable ? 1 : 0
   type        = "ingress"
   from_port   = 1194
   to_port     = 1194
   protocol    = "TCP"
   cidr_blocks = ["0.0.0.0/0"]
 
-  security_group_id = "${aws_security_group.bastion.id}"
+  security_group_id = aws_security_group.bastion.id
 }
 
 resource "aws_security_group_rule" "vpn-udp" {
-  count       = "${var.bastion-vpn-enable}"
+  count       = var.bastion-vpn-enable ? 1 : 0
   type        = "ingress"
   from_port   = 1194
   to_port     = 1194
   protocol    = "UDP"
   cidr_blocks = ["0.0.0.0/0"]
 
-  security_group_id = "${aws_security_group.bastion.id}"
+  security_group_id = aws_security_group.bastion.id
 }

--- a/modules/aws-vpc/cloudinit.tf
+++ b/modules/aws-vpc/cloudinit.tf
@@ -1,17 +1,17 @@
 data "template_file" "ssh_keys" {
-  count    = "${length(var.ssh-public-keys)}"
+  count    = length(var.ssh-public-keys)
   template = "- $${ssh-public-key}"
 
-  vars {
-    ssh-public-key = "${element("${var.ssh-public-keys}", count.index)}"
+  vars = {
+    ssh-public-key = element(var.ssh-public-keys, count.index)
   }
 }
 
 data "template_file" "cloud-init" {
-  template = "${file("${path.module}/cloudinit/userdata-template.yml")}"
+  template = file("${path.module}/cloudinit/userdata-template.yml")
 
-  vars {
-    ssh-authorized-keys = "${indent(2, join("\n", "${data.template_file.ssh_keys.*.rendered}"))}"
+  vars = {
+    ssh-authorized-keys = indent(2, join("\n", data.template_file.ssh_keys.*.rendered))
   }
 }
 
@@ -21,6 +21,6 @@ data "template_cloudinit_config" "config" {
   part {
     filename     = "ssh-authorized-keys.cfg"
     content_type = "text/cloud-config"
-    content      = "${data.template_file.cloud-init.rendered}"
+    content      = data.template_file.cloud-init.rendered
   }
 }

--- a/modules/aws-vpc/input.tf
+++ b/modules/aws-vpc/input.tf
@@ -1,70 +1,70 @@
 variable "vpc-cidr" {
-  type    = "string"
+  type    = string
   default = "10.10.0.0/16"
 }
 
 variable "az-count" {
-  type        = "string"
+  type        = string
   description = "Number of az to deploy the VPC in"
   default     = 3
 }
 
 variable "bastion-vpn-enable" {
-  type    = "string"
+  type    = string
   default = true
 }
 
 variable "bastion-ssh-enable" {
-  type    = "string"
+  type    = string
   default = true
 }
 
 variable "name" {
-  type = "string"
+  type = string
 }
 
 variable "env" {
-  type = "string"
+  type = string
 }
 
 variable "region" {
-  type    = "string"
+  type    = string
   default = "eu-west-1"
 }
 
 variable "internal-zone" {
-  type        = "string"
+  type        = string
   description = "Domain name for internal services"
 }
 
 variable "additional-zone" {
-  type        = "string"
+  type        = string
   default     = ""
   description = "Additional domain name for internal services"
 }
 
 variable "bastion-instance-type" {
-  type    = "string"
+  type    = string
   default = "t3.small"
 }
 
 variable "bastion-count" {
-  type    = "string"
+  type    = string
   default = 2
 }
 
 variable "bastion-ami" {
-  type    = "string"
+  type    = string
   default = "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*"
 }
 
 variable "ssh-public-keys" {
-  type        = "list"
+  type        = list
   description = "List of public SSH keys authorized to connect to the bastions"
 }
 
 variable "bastion-ami-owner" {
-  type = "string"
+  type = string
   default = "099720109477"
   description = "Bastion nodes AMI Owner"
 }
@@ -72,11 +72,11 @@ variable "bastion-ami-owner" {
 
 data "aws_ami" "main" {
   most_recent = true
-  owners = ["${var.bastion-ami-owner}"]
+  owners = [var.bastion-ami-owner]
 
   filter {
     name   = "name"
-    values = ["${var.bastion-ami}"]
+    values = [var.bastion-ami]
   }
 }
 

--- a/modules/aws-vpc/ouput.tf
+++ b/modules/aws-vpc/ouput.tf
@@ -1,31 +1,31 @@
 output "vpc" {
-  value = "${aws_vpc.main.id}"
+  value = aws_vpc.main.id
 }
 
 output "public_subnets" {
-  value = "${flatten(aws_subnet.public.*.id)}"
+  value = flatten(aws_subnet.public.*.id)
 }
 
 output "private_subnets" {
-  value = "${flatten(aws_subnet.private.*.id)}"
+  value = flatten(aws_subnet.private.*.id)
 }
 
 output "domain_zone" {
-  value = "${aws_route53_zone.main.id}"
+  value = aws_route53_zone.main.id
 }
 
 output "additional_zone" {
-  value = "${aws_route53_zone.additional.*.id}"
+  value = aws_route53_zone.additional.*.id
 }
 
 output "bastion_private_ip" {
-  value = "${flatten(aws_instance.bastion.*.private_ip)}"
+  value = flatten(aws_instance.bastion.*.private_ip)
 }
 
 output "bastion_public_ip" {
-  value = "${flatten(aws_eip.bastion.*.public_ip)}"
+  value = flatten(aws_eip.bastion.*.public_ip)
 }
 
 output "main_internet_gateway" {
-  value = "${aws_internet_gateway.main.id}"
+  value = aws_internet_gateway.main.id
 }

--- a/modules/aws-vpc/private.tf
+++ b/modules/aws-vpc/private.tf
@@ -1,33 +1,33 @@
 resource "aws_subnet" "private" {
-  count                   = "${var.az-count}"
-  availability_zone       = "${data.aws_availability_zones.available.names[count.index]}"
-  vpc_id                  = "${aws_vpc.main.id}"
-  cidr_block              = "${cidrsubnet(var.vpc-cidr, 8, count.index+10)}"
+  count                   = var.az-count
+  availability_zone       = data.aws_availability_zones.available.names[count.index]
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = cidrsubnet(var.vpc-cidr, 8, count.index+10)
   map_public_ip_on_launch = false
 
-  tags {
+  tags = {
     Name = "private-${var.name}-${var.env}-${count.index}"
   }
 }
 
 resource "aws_route_table" "private" {
-  vpc_id = "${aws_vpc.main.id}"
-  count  = "${var.az-count}"
+  vpc_id = aws_vpc.main.id
+  count  = var.az-count
 
-  tags {
+  tags = {
     Name = "private-${var.name}-${var.env}-${count.index+1}"
   }
 }
 
 resource "aws_route" "private" {
-  count                  = "${var.az-count}"
-  route_table_id         = "${element(aws_route_table.private.*.id,count.index)}"
-  nat_gateway_id         = "${element(aws_nat_gateway.main.*.id,count.index)}"
+  count                  = var.az-count
+  route_table_id         = element(aws_route_table.private.*.id,count.index)
+  nat_gateway_id         = element(aws_nat_gateway.main.*.id,count.index)
   destination_cidr_block = "0.0.0.0/0"
 }
 
 resource "aws_route_table_association" "private" {
-  count          = "${var.az-count}"
-  subnet_id      = "${element(aws_subnet.private.*.id, count.index)}"
-  route_table_id = "${element(aws_route_table.private.*.id, count.index)}"
+  count          = var.az-count
+  subnet_id      = element(aws_subnet.private.*.id, count.index)
+  route_table_id = element(aws_route_table.private.*.id, count.index)
 }

--- a/modules/aws-vpc/public.tf
+++ b/modules/aws-vpc/public.tf
@@ -1,56 +1,56 @@
 resource "aws_subnet" "public" {
-  count                   = "${var.az-count}"
-  availability_zone       = "${data.aws_availability_zones.available.names[count.index]}"
-  vpc_id                  = "${aws_vpc.main.id}"
-  cidr_block              = "${cidrsubnet(var.vpc-cidr, 8, count.index)}"
+  count                   = var.az-count
+  availability_zone       = data.aws_availability_zones.available.names[count.index]
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = cidrsubnet(var.vpc-cidr, 8, count.index)
   map_public_ip_on_launch = true
 
-  tags {
+  tags = {
     Name = "public-${var.name}-${var.env}-${count.index}"
   }
 }
 
 resource "aws_internet_gateway" "main" {
-  vpc_id = "${aws_vpc.main.id}"
+  vpc_id = aws_vpc.main.id
 }
 
 resource "aws_eip" "main" {
-  count      = "${var.az-count}"
+  count      = var.az-count
   vpc        = true
-  depends_on = ["aws_internet_gateway.main"]
+  depends_on = [aws_internet_gateway.main]
 
-  tags {
+  tags = {
     Name = "nat-${var.name}-${var.env}-${count.index+1}"
   }
 }
 
 resource "aws_nat_gateway" "main" {
-  count         = "${var.az-count}"
-  allocation_id = "${element(aws_eip.main.*.id, count.index)}"
-  subnet_id     = "${element(aws_subnet.public.*.id,count.index)}"
-  depends_on    = ["aws_internet_gateway.main"]
+  count         = var.az-count
+  allocation_id = element(aws_eip.main.*.id, count.index)
+  subnet_id     = element(aws_subnet.public.*.id,count.index)
+  depends_on    = [aws_internet_gateway.main]
 
-  tags {
+  tags = {
     Name = "nat-${var.name}-${var.env}-${count.index+1}"
   }
 }
 
 resource "aws_route_table" "public" {
-  vpc_id = "${aws_vpc.main.id}"
+  vpc_id = aws_vpc.main.id
 
-  tags {
+  tags = {
     Name = "public-${var.name}-${var.env}"
   }
 }
 
 resource "aws_route" "main" {
-  route_table_id         = "${aws_route_table.public.id}"
-  gateway_id             = "${aws_internet_gateway.main.id}"
+  route_table_id         = aws_route_table.public.id
+  gateway_id             = aws_internet_gateway.main.id
   destination_cidr_block = "0.0.0.0/0"
 }
 
 resource "aws_route_table_association" "public" {
-  count          = "${var.az-count}"
-  subnet_id      = "${element(aws_subnet.public.*.id,count.index)}"
-  route_table_id = "${aws_route_table.public.id}"
+  count          = var.az-count
+  subnet_id      = element(aws_subnet.public.*.id,count.index)
+  route_table_id = aws_route_table.public.id
 }

--- a/modules/aws-vpc/route53.tf
+++ b/modules/aws-vpc/route53.tf
@@ -1,16 +1,16 @@
 resource "aws_route53_zone" "main" {
-  name = "${var.internal-zone}"
+  name = var.internal-zone
 
   vpc {
-    vpc_id = "${aws_vpc.main.id}"
+    vpc_id = aws_vpc.main.id
   }
 }
 
 resource "aws_route53_zone" "additional" {
-  count = "${var.additional-zone == "" ? 0 : 1}"
-  name  = "${var.additional-zone}"
+  count = var.additional-zone == "" ? 0 : 1
+  name  = var.additional-zone
 
   vpc {
-    vpc_id = "${aws_vpc.main.id}"
+    vpc_id = aws_vpc.main.id
   }
 }

--- a/modules/aws-vpc/vpc.tf
+++ b/modules/aws-vpc/vpc.tf
@@ -1,9 +1,9 @@
 resource "aws_vpc" "main" {
-  cidr_block           = "${var.vpc-cidr}"
+  cidr_block           = var.vpc-cidr
   enable_dns_support   = true
   enable_dns_hostnames = true
 
-  tags {
+  tags = {
     Name = "vpc-${var.name}-${var.env}"
   }
 }


### PR DESCRIPTION
Even if this repository is deprecated in favor of [sighupio/fury-eks-installer](https://github.com/sighupio/fury-eks-installer) we still need to support it. Therefore I am updating the code of `aws-kubernetes` module to be used with Terraform 0.12.x.

Summary of changes:
  - updated HCL syntax to Terraform 0.12
  - added some useful outputs
  - added kubernetes tags to node security group to make service `type: LoadBalancer` work
  - removed weave-net security rules

This PR is related to sighupio/fury-kubernetes-aws#44, I chose to split the two PRs to ease the review process. If that's not the case, I can merge them. Let me know.