### PR TITLE
Cron for crl updates

### DIFF
--- a/roles/furyagent/tasks/main.yml
+++ b/roles/furyagent/tasks/main.yml
@@ -78,6 +78,13 @@
   command: "furyagent configure openvpn --config={{ furyagent_config_dir }}/{{ furyagent_config_name }} --overwrite=true"
   when: furyagent_configure_openvpn
 
+- name: Configuring OpenVPN cron for furyagent
+  cron:
+    name: "Furyagent configure openvpn from s3"
+    minute: "*/5"
+    job: "/usr/local/bin/furyagent configure openvpn --config={{ furyagent_config_dir }}/{{ furyagent_config_name }} --overwrite=true"
+  when: furyagent_configure_openvpn
+
 - name: Configure Etcd backup every 15 minutes with furyagent
   cron:
     minute: "*/10"


### PR DESCRIPTION
Hi guys!

I added a little cron to automatically update openvpn servers certs, mainly for crl list updates. This way we can automatically download all the new revoke definitions from s3