### PR TITLE
Adding servers list on openvpn-furyagent.yml file to skip manual fix + cron for crl

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -1,0 +1,16 @@
+# Fury Kubernetes AWS Module version unreleased
+
+SIGHUP team maintains this module updated and tested. This release contains improvements and new features.
+
+Continue reading the [Changelog](#changelog) to discover them:
+
+## Changelog
+
+- Adding crl cron for vpn servers. The update is scheduled every 5 minutes. All the certs and crl definitions will be updated by furyagent.
+- Fixing the output for the `openvpn-furyagent.yml` with the correct server list
+
+
+## Upgrade path
+
+Simply upgrade from the previous version. No changes needed.
+

--- a/roles/furyagent/tasks/main.yml
+++ b/roles/furyagent/tasks/main.yml
@@ -78,6 +78,13 @@
   command: "furyagent configure openvpn --config={{ furyagent_config_dir }}/{{ furyagent_config_name }} --overwrite=true"
   when: furyagent_configure_openvpn
 
+- name: Configuring OpenVPN cron for furyagent
+  cron:
+    name: "Furyagent configure openvpn from s3"
+    minute: "*/5"
+    job: "/usr/local/bin/furyagent configure openvpn --config={{ furyagent_config_dir }}/{{ furyagent_config_name }} --overwrite=true"
+  when: furyagent_configure_openvpn
+
 - name: Configure Etcd backup every 15 minutes with furyagent
   cron:
     minute: "*/10"

--- a/roles/furyagent/templates/furyagent.yml.j2
+++ b/roles/furyagent/templates/furyagent.yml.j2
@@ -37,6 +37,8 @@ clusterComponent:
 {% if furyagent_configure_openvpn %}
   openvpn:
     certDir: {{ furyagent_openvpn_certs_dir }}
-  openvpn-client:
-    targetDir: {{ secrets_path }}/users/openvpn
+    servers:
+{% for server in ansible_play_hosts_all %}
+      - {{ hostvars[server]['ansible_host'] }}
+{% endfor %}
 {% endif %}


### PR DESCRIPTION
Hi all! Another little PR to fix the openvpn-furyagent.yml file generation with the correct servers list