### PR TITLE
Increasing the resource limit of the cluster autoscaler

### DIFF
--- a/katalog/clusterautoscaler/deployment.yml
+++ b/katalog/clusterautoscaler/deployment.yml
@@ -24,8 +24,8 @@ spec:
           name: cluster-autoscaler
           resources:
             limits:
-              cpu: 100m
-              memory: 300Mi
+              cpu: "1"
+              memory: 800Mi
             requests:
               cpu: 100m
               memory: 300Mi


### PR DESCRIPTION
This increases the CPU limit to 1 core and memory limit to 800Mi. This fixes the issue #53 