### PR TITLE
Feature/cluster-autoscaler-1.24

### DIFF
--- a/katalog/cluster-autoscaler/MAINTENANCE.md
+++ b/katalog/cluster-autoscaler/MAINTENANCE.md
@@ -19,7 +19,8 @@ Check the differences with `base/deploy.yaml` file and change accordingly.
 What was changed:
 
 - Removed unnecessary helm tags from the manifests and replaced with `app: cluster-autoscaler` when applicable, to maintain compatibility with older cluster-autoscaler package versions.
-- cluster-autoscaler command changed to: 
+- cluster-autoscaler command changed to:
+
   ```yaml
   command:
     - ./cluster-autoscaler
@@ -33,8 +34,9 @@ What was changed:
     - --expander=least-waste
     - --node-group-auto-discovery=asg:tag=k8s.io/cluster-autoscaler/enabled,k8s.io/cluster-autoscaler/$(CLUSTER_NAME)
   ```
+
 - Added env var `CLUSTER_NAME` to the deployment, to simplify patching
 - Added requests and limits
 - Removed PodDisruptionBudget
 
-Add the new EKS version folder like the existing v1.21.x, v1.22.x, v1.23.x if needed.
+Add the new EKS version folder like the existing v1.21.x, v1.22.x, v1.23.x, etc. if needed.

--- a/katalog/cluster-autoscaler/README.md
+++ b/katalog/cluster-autoscaler/README.md
@@ -11,30 +11,30 @@ A component that automatically adjusts the size of a Kubernetes Cluster so that 
 
 ## Image repository and tag
 
-* Cluster autoscaler image: `registry.sighup.io/autoscaling/cluster-autoscaler:v1.21.3,v1.22.3,v1.23.1`
-* Cluster autoscaler repo: [Cluster autoscaler at Github][github]
+- Cluster autoscaler image: `registry.sighup.io/autoscaling/cluster-autoscaler:v1.21.3,v1.22.3,v1.23.1,v1.24.0`
+- Cluster autoscaler repo: [Cluster autoscaler at Github][ca-github]
 
 ## Deployment
 
-You can deploy cluster autoscaler in your EKS cluster by including the package in your kustomize project:
+You can deploy cluster autoscaler in your EKS cluster by including the package in your Kustomize project:
 
 `kustomization.yaml` file extract:
+
 ```yaml
 ...
 
 resources:
-  - katalog/cluster-autoscaler/{v1.21.x,v1.22.x,v1.23.x}
+  - katalog/cluster-autoscaler/{v1.21.x,v1.22.x,v1.23.x,v1.24.x}
 
 ...
 ```
 
-Refer to the Terraform module [iam-for-cluster-autoscaler](../../modules/iam-for-cluster-autoscaler) to create the
-IAM role and the required kustomize patches automatically.
+Refer to the Terraform module [iam-for-cluster-autoscaler](../../modules/iam-for-cluster-autoscaler) to create the IAM role and the required kustomize patches automatically.
 
-If still you want to create everything manually without using our Terraform Module, you need to patch the service account, the cluster name
-(for example `mycluster`) and the region (for example `eu-west-1`) as follows:
+If still you want to create everything manually without using our Terraform Module, you need to patch the service account, the cluster name (for example `mycluster`) and the region (for example `eu-west-1`) as follows:
 
 `sa-patch.yaml`
+
 ```yaml
 ---
 apiVersion: v1
@@ -47,6 +47,7 @@ metadata:
 ```
 
 `cluster-autoscaler-patch.yaml`
+
 ```yaml
 apiVersion: apps/v1
 kind: Deployment
@@ -70,6 +71,7 @@ spec:
 and then add on the `kustomization.yaml` file the patches:
 
 `kustomization.yaml` file extract:
+
 ```yaml
 ...
 
@@ -88,12 +90,10 @@ kustomize build | kubectl apply -f -
 
 <!-- Links -->
 
-[github]: https://github.com/kubernetes/autoscaler
+[ca-github]: https://github.com/kubernetes/autoscaler
 
 <!-- </KFD-DOCS> -->
 
 ## License
 
 For license details please see [LICENSE](../../LICENSE)
-
-

--- a/katalog/cluster-autoscaler/v1.24.x/kustomization.yaml
+++ b/katalog/cluster-autoscaler/v1.24.x/kustomization.yaml
@@ -1,0 +1,16 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: kube-system
+
+resources:
+  - ../base
+
+images:
+  - name: registry.sighup.io/fury/autoscaling/cluster-autoscaler
+    newTag: v1.24.0

--- a/katalog/ebs-csi-driver/MAINTENANCE.md
+++ b/katalog/ebs-csi-driver/MAINTENANCE.md
@@ -20,12 +20,13 @@ Then, you should update the `ebs-csi-driver` package with the new `built-ebs.yam
 Check the differences with `deploy-ebs-driver.yaml` file and change accordingly.
 
 What was changed:
+
 - removed all the empty references to secrets or configmaps
 - removed PodDisruptionBudget
 
 ## Snapshotter side component
 
-Download the latest release for the CSI snapshotter component here: https://github.com/kubernetes-csi/external-snapshotter and extract it on `/tmp` folder.
+Download the latest release for the CSI snapshotter component here: <https://github.com/kubernetes-csi/external-snapshotter> and extract it on `/tmp` folder.
 
 Build manifests for the CRDs and the snapshotter with (for example):
 
@@ -35,8 +36,10 @@ kustomize build /tmp/external-snapshotter-6.0.1/deploy/kubernetes/snapshot-contr
 ```
 
 Check the differences between:
+
 - `built-crds.yaml` and `./crds/crds.yaml`
 - `built-snapshot-controller.yaml` and `./deploy-snapshot-controller.yaml`
 
-What was changed: 
+What was changed:
+
 - snapshot-controller Deployment replicas from 2 to 1

--- a/katalog/load-balancer-controller/MAINTENANCE.md
+++ b/katalog/load-balancer-controller/MAINTENANCE.md
@@ -2,11 +2,12 @@
 
 To maintain the AWS load balancer controller package, you should follow these steps.
 
-Go to https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.4/deploy/installation/ and follow the steps for
+Go to <https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.4/deploy/installation/> and follow the steps for
 the non-helm installation.
 
-Get the yaml file, for example https://github.com/kubernetes-sigs/aws-load-balancer-controller/releases/download/v2.4.3/v2_4_3_full.yaml
+Get the yaml file, for example <https://github.com/kubernetes-sigs/aws-load-balancer-controller/releases/download/v2.4.3/v2_4_3_full.yaml>
 and compare it with `deploy.yaml` file.
 
 What was changed:
+
 - Moved cluster name to an environment variable `CLUSTER_NAME`

--- a/modules/iam-for-cluster-autoscaler/README.md
+++ b/modules/iam-for-cluster-autoscaler/README.md
@@ -1,6 +1,6 @@
 # IAM for cluster autoscaler
 
-This terraform module provides an easy way to generate cluster autoscaler required IAM permissions.
+This terraform module provides an easy way to generate required IAM permissions for cluster autoscaler.
 
 > ⚠️ **Warning**: this module uses ["IAM Roles for ServiceAccount"](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) to inject AWS credentials inside cluster autoscaler pods
 
@@ -30,7 +30,6 @@ This terraform module provides an easy way to generate cluster autoscaler requir
 | ---------------------------------- | --------------------------------------- |
 | cluster\_autoscaler\_patches       | Cluster autoscaler SA Kustomize patch   |
 | cluster\_autoscaler\_iam\_role\_arn  | Cluster autoscaler IAM role arn       |
-
 
 ## Usage
 


### PR DESCRIPTION
Add needed files to support Kubernetes 1.24 in cluster-autoscaler package.

Even though the other packages have updates available, from their docs our current versions seem to be compatible with Kubernetes 1.24, so I consider that this PR fixes #63

PS: Container Image has already been synced with this commit: https://github.com/sighupio/fury-distribution-container-image-sync/commit/a62e7f99e64ff00455897b4981fe6bc9fb0ad0b9