### PR TITLE
Prepare Release v2.1.0

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,163 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+name: license
+kind: pipeline
+type: docker
+
+steps:
+  - name: check
+    image: golang:1.18.1-alpine
+    pull: always
+    commands:
+      - go install github.com/google/addlicense@v1.0.0
+      - addlicense -c "SIGHUP s.r.l" -v -l bsd -y "2017-present" --check .
+
+---
+name: policeman
+kind: pipeline
+type: docker
+
+depends_on:
+  - license
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+  - name: lint
+    image: quay.io/sighup/policeman
+    pull: always
+    environment:
+      # Identifies false positives like missing 'selector'.
+      # Doing this is valid for Kustomize patches
+      VALIDATE_KUBERNETES_KUBEVAL: "false"
+      # Some duplicated code is intended.
+      VALIDATE_JSCPD: "false"
+      # hadolint already validated dockerfiles
+      VALIDATE_DOCKERFILE: "false"
+      # Disable natural language checks
+      VALIDATE_NATURAL_LANGUAGE: "false"
+    depends_on:
+      - clone
+
+  - name: render
+    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.9.4_1.20.7_3.8.7_2.4.1
+    pull: always
+    commands:
+      - kustomize build katalog/cluster-autoscaler/v1.21.x > cluster-autoscaler-v1.21.x.yml
+      - kustomize build katalog/cluster-autoscaler/v1.22.x > cluster-autoscaler-v1.22.x.yml
+      - kustomize build katalog/cluster-autoscaler/v1.23.x > cluster-autoscaler-v1.23.x.yml
+      - kustomize build katalog/cluster-autoscaler/v1.24.x > cluster-autoscaler-v1.24.x.yml
+      - kustomize build katalog/ebs-csi-driver > ebs-csi-driver.yml
+      - kustomize build katalog/load-balancer-controller > load-balancer-controller.yml
+      - kustomize build katalog/node-termination-handler > node-termination-handler.yml
+
+
+  - name: check-deprecated-apis
+    image: us-docker.pkg.dev/fairwinds-ops/oss/pluto:v5
+    pull: always
+    depends_on:
+      - render
+    commands:
+      # we use --ignore-deprecations because we don't want the CI to fail when the API has not been removed yet.
+      - /pluto detect cluster-autoscaler-v1.21.x.yml --ignore-deprecations --target-versions=k8s=v1.21.0
+      - /pluto detect cluster-autoscaler-v1.22.x.yml --ignore-deprecations --target-versions=k8s=v1.22.0
+      - /pluto detect cluster-autoscaler-v1.23.x.yml --ignore-deprecations --target-versions=k8s=v1.23.0
+      - /pluto detect cluster-autoscaler-v1.24.x.yml --ignore-deprecations --target-versions=k8s=v1.24.0
+      - /pluto detect ebs-csi-driver.yml --ignore-deprecations --target-versions=k8s=v1.24.0
+      - /pluto detect load-balancer-controller.yml --ignore-deprecations --target-versions=k8s=v1.24.0
+      - /pluto detect node-termination-handler.yml --ignore-deprecations --target-versions=k8s=v1.24.0
+
+---
+name: release
+kind: pipeline
+type: docker
+
+# Uncomment once we have e2e tests
+# depends_on:
+# - e2e-kubernetes-1.20
+
+platform:
+  os: linux
+  arch: amd64
+
+trigger:
+  ref:
+    include:
+      - refs/tags/**
+
+steps:
+  - name: prepare-tar-gz
+    image: alpine:latest
+    pull: always
+    depends_on: [clone]
+    commands:
+      - tar -zcvf kubernetes-fury-aws-${DRONE_TAG}.tar.gz katalog/ LICENSE README.md
+    when:
+      ref:
+        include:
+          - refs/tags/**
+
+  - name: prepare-release-notes
+    image: quay.io/sighup/fury-release-notes-plugin:3.7_2.8.4
+    pull: always
+    depends_on: [clone]
+    settings:
+      release_notes_file_path: release-notes.md
+    when:
+      ref:
+        include:
+          - refs/tags/**
+
+  - name: publish-prerelease
+    image: plugins/github-release
+    pull: always
+    depends_on:
+      - prepare-tar-gz
+      - prepare-release-notes
+    settings:
+      api_key:
+        from_secret: github_token
+      file_exists: overwrite
+      files:
+        - kubernetes-fury-aws-${DRONE_TAG}.tar.gz
+      prerelease: true
+      overwrite: true
+      title: "Preview ${DRONE_TAG}"
+      note: release-notes.md
+      checksum:
+        - md5
+        - sha256
+    when:
+      ref:
+        include:
+          - refs/tags/v**-rc**
+
+  - name: publish-stable
+    image: plugins/github-release
+    pull: always
+    depends_on:
+      - prepare-tar-gz
+      - prepare-release-notes
+    settings:
+      api_key:
+        from_secret: github_token
+      file_exists: overwrite
+      files:
+        - kubernetes-fury-aws-${DRONE_TAG}.tar.gz
+      prerelease: false
+      overwrite: true
+      title: "Release ${DRONE_TAG}"
+      note: release-notes.md
+      checksum:
+        - md5
+        - sha256
+    when:
+      ref:
+        exclude:
+          - refs/tags/v**-rc**
+        include:
+          - refs/tags/v**

--- a/.drone.yml
+++ b/.drone.yml
@@ -8,7 +8,7 @@ type: docker
 
 steps:
   - name: check
-    image: golang:1.18.1-alpine
+    image: golang:1.19.4-alpine
     pull: always
     commands:
       - go install github.com/google/addlicense@v1.0.0

--- a/.drone.yml
+++ b/.drone.yml
@@ -40,6 +40,8 @@ steps:
       VALIDATE_DOCKERFILE: "false"
       # Disable natural language checks
       VALIDATE_NATURAL_LANGUAGE: "false"
+      # Exclude old release notes that were created before we introduced policeman
+      FILTER_REGEX_EXCLUDE: (docs/releases/v1[.]15[.].*[.]md)
     depends_on:
       - clone
 

--- a/README.md
+++ b/README.md
@@ -21,25 +21,26 @@ If you are new to KFD please refer to the [official documentation][kfd-docs] on 
 
 The following packages are included in Kubernetes Fury AWS:
 
-| Package                                                                               | Version                   | Description                                                                                                            |
-|---------------------------------------------------------------------------------------|---------------------------|------------------------------------------------------------------------------------------------------------------------|
-| [cluster-autoscaler](katalog/cluster-autoscaler)                                      | `v1.21.3/v1.22.3/v1.23.1` | A component that automatically adjusts the size of a Kubernetes Cluster                                                |
-| [IAM role for cluster-autoscaler](modules/iam-for-cluster-autoscaler)                 | `-`                       | Terraform module to manage IAM role used by cluster-autoscaler                                                         |
-| [aws-node-termination-handler](katalog/node-termination-handler)                      | `v1.17.1`                 | Automatically manage graceful termination of pods in the event that one node is retired by AWS                         |
-| [aws-load-balancer-controller](katalog/load-balancer-controller)                      | `v2.4.3`                  | AWS Load Balancer Controller is a controller to help manage Elastic Load Balancers for a Kubernetes cluster            |
-| [IAM role for aws-load-balancer-controller](modules/iam-for-load-balancer-controller) | `-`                       | Terraform module to manage IAM role used by aws-load-balancer-controller                                               |
-| [aws-ebs-csi-driver](katalog/ebs-csi-driver)                                          | `v1.11.2`                 | The Amazon EBS (CSI) Driver provides a CSI interface used by Kubernetes to manage the lifecycle of Amazon EBS volumes. |
-| [IAM role for aws-ebs-csi-driver](modules/iam-for-ebs-csi-driver)                     | `-`                       | Terraform module to manage IAM role used by EBS CSI driver                                                             |
+| Package                                                                               | Version                           | Description                                                                                                            |
+| ------------------------------------------------------------------------------------- | --------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| [cluster-autoscaler](katalog/cluster-autoscaler)                                      | `v1.21.3/v1.22.3/v1.23.1/v1.24.0` | A component that automatically adjusts the size of a Kubernetes Cluster                                                |
+| [IAM role for cluster-autoscaler](modules/iam-for-cluster-autoscaler)                 | `-`                               | Terraform module to manage IAM role used by cluster-autoscaler                                                         |
+| [aws-node-termination-handler](katalog/node-termination-handler)                      | `v1.17.1`                         | Automatically manage graceful termination of pods in the event that one node is retired by AWS                         |
+| [aws-load-balancer-controller](katalog/load-balancer-controller)                      | `v2.4.3`                          | AWS Load Balancer Controller is a controller to help manage Elastic Load Balancers for a Kubernetes cluster            |
+| [IAM role for aws-load-balancer-controller](modules/iam-for-load-balancer-controller) | `-`                               | Terraform module to manage IAM role used by aws-load-balancer-controller                                               |
+| [aws-ebs-csi-driver](katalog/ebs-csi-driver)                                          | `v1.11.2`                         | The Amazon EBS (CSI) Driver provides a CSI interface used by Kubernetes to manage the lifecycle of Amazon EBS volumes. |
+| [IAM role for aws-ebs-csi-driver](modules/iam-for-ebs-csi-driver)                     | `-`                               | Terraform module to manage IAM role used by EBS CSI driver                                                             |
 
 Click on each package to see its full documentation.
 
 ## Compatibility
 
-| Kubernetes Version |   Compatibility    | Notes                                               |
-|--------------------|:------------------:|-----------------------------------------------------|
-| `1.21.x`           | :white_check_mark: | No known issues                                     |
-| `1.22.x`           | :white_check_mark: | No known issues                                     |
-| `1.23.x`           | :white_check_mark: | No known issues                                     |
+| Kubernetes Version |   Compatibility    | Notes           |
+| ------------------ | :----------------: | --------------- |
+| `1.21.x`           | :white_check_mark: | No known issues |
+| `1.22.x`           | :white_check_mark: | No known issues |
+| `1.23.x`           | :white_check_mark: | No known issues |
+| `1.24.x`           | :white_check_mark: | No known issues |
 
 Check the [compatibility matrix][compatibility-matrix] for additional informations about previous releases of the modules.
 
@@ -47,11 +48,11 @@ Check the [compatibility matrix][compatibility-matrix] for additional informatio
 
 ### Prerequisites
 
-| Tool                        | Version   | Description                                                                                                                                                    |
-|-----------------------------|-----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| [furyctl][furyctl-repo]     | `>=0.6.0` | The recommended tool to download and manage KFD modules and their packages. To learn more about `furyctl` read the [official documentation][furyctl-repo].     |
-| [kustomize][kustomize-repo] | `>=3.5.3` | Packages are customized using `kustomize`. To learn how to create your customization layer with `kustomize`, please refer to the [repository][kustomize-repo]. |
-| [terraform][terraform-repo] | `>=0.15.4`| Terraform is used to provision packages using modules. To learn how to use `terraform`, please refer to the [repository][terraform-repo].                      |
+| Tool                        | Version    | Description                                                                                                                                                    |
+| --------------------------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [furyctl][furyctl-repo]     | `>=0.6.0`  | The recommended tool to download and manage KFD modules and their packages. To learn more about `furyctl` read the [official documentation][furyctl-repo].     |
+| [kustomize][kustomize-repo] | `>=3.5.3`  | Packages are customized using `kustomize`. To learn how to create your customization layer with `kustomize`, please refer to the [repository][kustomize-repo]. |
+| [terraform][terraform-repo] | `>=0.15.4` | Terraform is used to provision packages using modules. To learn how to use `terraform`, please refer to the [repository][terraform-repo].                      |
 
 ### Deployment
 
@@ -60,13 +61,13 @@ Check the [compatibility matrix][compatibility-matrix] for additional informatio
 ```yaml
 bases:
   - name: aws/cluster-autoscaler
-    version: "v2.0.0"
+    version: "v2.1.0"
   - name: aws/node-termination-handler
-    version: "v2.0.0"
+    version: "v2.1.0"
   - name: aws/load-balancer-controller
-    version: "v2.0.0"
+    version: "v2.1.0"
   - name: aws/ebs-csi-driver
-    version: "v2.0.0" 
+    version: "v2.1.0" 
 ```
 
 > See `furyctl` [documentation][furyctl-repo] for additional details about `Furyfile.yml` format.
@@ -79,7 +80,7 @@ bases:
 
 ```yaml
 resources:
-- ./vendor/katalog/aws/cluster-autoscaler/{v1.21.x,v1.22.x,v1.23.x}
+- ./vendor/katalog/aws/cluster-autoscaler/{v1.21.x,v1.22.x,v1.23.x,v1.24.x}
 - ./vendor/katalog/aws/node-termination-handler
 - ./vendor/katalog/aws/load-balancer-controller
 - ./vendor/katalog/aws/ebs-csi-driver

--- a/docs/releases/COMPATIBILITY_MATRIX.md
+++ b/docs/releases/COMPATIBILITY_MATRIX.md
@@ -1,0 +1,18 @@
+
+# Compatibility Matrix
+
+| Module Version / Kubernetes Version |       1.21.X       |       1.22.X       |       1.23.X       |       1.24.X       |
+| ----------------------------------- | :----------------: | :----------------: | :----------------: | :----------------: |
+| v1.x                                |        :x:         |        :x:         |        :x:         |         :x         |
+| v2.0.0                              | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |
+| v2.1.0                              | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+
+:white_check_mark: Compatible
+
+:warning: Has issues
+
+:x: Incompatible
+
+## Warnings
+
+- Module has been completely repurposed on v2.0.0, breaking all compatbility with previous versions.

--- a/docs/releases/COMPATIBILITY_MATRIX.md
+++ b/docs/releases/COMPATIBILITY_MATRIX.md
@@ -3,7 +3,7 @@
 
 | Module Version / Kubernetes Version |       1.21.X       |       1.22.X       |       1.23.X       |       1.24.X       |
 | ----------------------------------- | :----------------: | :----------------: | :----------------: | :----------------: |
-| v1.x                                |        :x:         |        :x:         |        :x:         |         :x         |
+| v1.x                                |        :x:         |        :x:         |        :x:         |        :x:         |
 | v2.0.0                              | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |
 | v2.1.0                              | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 

--- a/docs/releases/v2.0.0.md
+++ b/docs/releases/v2.0.0.md
@@ -28,9 +28,3 @@ This release completely removes all the terraform modules used for the installat
 There is no update guide since this release completeley changes the scope of this module, from a colleciton of packages to install a Kubernetes cluster on AWS to a collection of packages to install on top of an existing Kubernetes EKS/AWS cluster.
 
 <!-- Links -->
-
-
-
-
-
-

--- a/docs/releases/v2.0.0.md
+++ b/docs/releases/v2.0.0.md
@@ -17,7 +17,8 @@ Welcome to the latest release of `aws` module of the [`Kubernetes Fury Distribut
 
 ## New packages: Welcome EBS CSI Driver and AWS Load Balancer Controller! 📕
 
-This release adds two new packages, `ebs-csi-driver` and `load-balancer-controller`. The first one is a mandatory package to use EBS volumes in your EKS cluster, since from EKS version 1.23 the in-tree EBS volume plugin is deprecated. The second one is the official AWS controller to manage AWS Load Balancers, which is a mandatory package to use all the features provided from AWS on the Load Balancers, for example, enabling the proxy protocol on Network Load Balancers.
+This release adds two new packages, `ebs-csi-driver` and `load-balancer-controller`. The first one is a mandatory package to use EBS volumes in your EKS cluster, since from EKS version 1.23 the in-tree EBS volume plugin is deprecated.
+The second one is the official AWS controller to manage AWS Load Balancers, which is a mandatory package to use all the features provided from AWS on the Load Balancers, for example, enabling the proxy protocol on Network Load Balancers.
 
 ## Removals: Removed all the legacy terraform modules to install Kubernetes on EC2 🚮
 

--- a/docs/releases/v2.1.0.md
+++ b/docs/releases/v2.1.0.md
@@ -1,0 +1,24 @@
+# AWS Add-on Module Release 2.1.0
+
+Welcome to the latest release of the `aws` module for the [`Kubernetes Fury Distribution`](https://github.com/sighupio/fury-distribution) maintained by team SIGHUP.
+
+This is a minor release adding support for Kubernets `v1.24.x`.
+
+## Component Images 🚢
+
+| Component                  | Supported Version                                                                               | Previous Version |
+| -------------------------- | ----------------------------------------------------------------------------------------------- | ---------------- |
+| `cluster-austoscaler`      | [`v1.24.0`](https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.24.0)    | `1.23.1`         |
+| `ebs-csi-driver`           | [`v1.11.2`](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/releases/tag/v1.11.2)         | no change        |
+| `load-balancer-controller` | [`v2.4.3`](https://github.com/kubernetes-sigs/aws-load-balancer-controller/releases/tag/v2.4.3) | no change        |
+| `node-termination-handler` | [`v1.17.1`](https://github.com/aws/aws-node-termination-handler/releases/tag/v1.17.1)           | no change        |
+
+> Please refer to the individual release notes to get detailed information on each release.
+
+## Update Guide 🦮
+
+If you are upgrading Kubernetes together with the module, change your Kustomization file to use the right version of `cluster-autoscaler` and apply the manifests.
+
+There are no other changes needed.
+
+<!-- Links -->

--- a/katalog/ebs-csi-driver/crds/crds.yaml
+++ b/katalog/ebs-csi-driver/crds/crds.yaml
@@ -1,3 +1,7 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/katalog/load-balancer-controller/README.md
+++ b/katalog/load-balancer-controller/README.md
@@ -94,7 +94,7 @@ kustomize build | kubectl apply -f -
 
 <!-- Links -->
 
-[cert-manager]: https://github.com/sighupio/fury-kubernetes-ingress/tree/master/katalog/cert-manager 
+[cert-manager]: https://github.com/sighupio/fury-kubernetes-ingress/tree/master/katalog/cert-manager
 [github]: https://github.com/kubernetes-sigs/aws-load-balancer-controller/
 
 <!-- </KFD-DOCS> -->

--- a/katalog/load-balancer-controller/README.md
+++ b/katalog/load-balancer-controller/README.md
@@ -15,14 +15,15 @@ AWS Load Balancer Controller is a controller to help manage Elastic Load Balance
 
 ## Image repository and tag
 
-* AWS Load Balancer controller image: `registry.sighup.io/fury/amazon/aws-alb-ingress-controller:v2.4.3`
-* AWS Load Balancer controller repo: [AWS Load Balancer controller at Github][github]
+- AWS Load Balancer controller image: `registry.sighup.io/fury/amazon/aws-alb-ingress-controller:v2.4.3`
+- AWS Load Balancer controller repo: [AWS Load Balancer controller at Github][github]
 
 ## Deployment
 
 You can deploy AWS Load Balancer controller in your EKS cluster by including the package in your kustomize project:
 
 `kustomization.yaml` file extract:
+
 ```yaml
 ...
 
@@ -32,13 +33,12 @@ resources:
 ...
 ```
 
-Refer to the Terraform module [iam-for-load-balancer-controller](../../modules/iam-for-load-balancer-controller) to create the
-IAM role and the required kustomize patches automatically.
+Refer to the Terraform module [iam-for-load-balancer-controller](../../modules/iam-for-load-balancer-controller) to create the IAM role and the required kustomize patches automatically.
 
-If still you want to create everything manually without using our Terraform Module, you need then to patch the service
-account and the cluster name (for example `mycluster`) as follows:
+If still you want to create everything manually without using our Terraform Module, you need then to patch the service account and the cluster name (for example `mycluster`) as follows:
 
 `sa-patch.yaml`
+
 ```yaml
 ---
 kind: ServiceAccount
@@ -50,6 +50,7 @@ metadata:
 ```
 
 `load-balancer-controller-patch.yaml`
+
 ```yaml
 apiVersion: apps/v1
 kind: Deployment
@@ -74,6 +75,7 @@ spec:
 and then add on the `kustomization.yaml` file the patches:
 
 `kustomization.yaml` file extract:
+
 ```yaml
 ...
 
@@ -100,5 +102,3 @@ kustomize build | kubectl apply -f -
 ## License
 
 For license details please see [LICENSE](../../LICENSE)
-
-

--- a/katalog/node-termination-handler/README.md
+++ b/katalog/node-termination-handler/README.md
@@ -18,8 +18,8 @@ This package is deployed as Instance Metadata Service Processor to monitor:
 
 ## Image repository and tag
 
-* AWS node termination handler image: `registry.sighup.io/fury/aws-ec2/aws-node-termination-handler:v1.17.1`
-* AWS node termination handler repo: [AWS node termination handler at Github][github]
+- AWS node termination handler image: `registry.sighup.io/fury/aws-ec2/aws-node-termination-handler:v1.17.1`
+- AWS node termination handler repo: [AWS node termination handler at Github][github]
 
 ## Deployment
 


### PR DESCRIPTION
- add minimal CI with linting and release maangement
- fix linting issues in markdown and other files
- add missing copyright notice to ebs-csi-driver/crds.yaml
- add release notes for v2.1.0
- add missing compatibility matrix
- update docs for the new release