### PR TITLE
ci: introduce manifest testing with kube-linter

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -6,23 +6,33 @@ name: license
 kind: pipeline
 type: docker
 node:
-   performance: low
+  performance: low
 clone:
   depth: 1
+volumes:
+  - name: mise-cache
+    host:
+      path: /root/mise_data_dir
 steps:
   - name: check
-    image: docker.io/library/golang:1.21
+    image: quay.io/sighup/mise:v2026.6.14
     pull: always
+    environment:
+      MISE_DATA_DIR: /mise-data
+      GITHUB_TOKEN:
+        from_secret: github_token
+    volumes:
+      - name: mise-cache
+        path: /mise-data
     commands:
-      - go install github.com/google/addlicense@v1.1.1
-      - addlicense -c "SIGHUP s.r.l" -v -l bsd --check .
+      - mise run check-license
 
 ---
-name: linting
+name: validate
 kind: pipeline
 type: docker
 node:
-   performance: low
+  performance: low
 depends_on:
   - license
 clone:
@@ -36,11 +46,10 @@ volumes:
       path: /root/mise_data_dir
 steps:
   - name: render
-    image: quay.io/sighup/mise:v2025.4.4
+    image: quay.io/sighup/mise:v2026.6.14
     pull: always
     environment:
       MISE_DATA_DIR: /mise-data
-      MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
       GITHUB_TOKEN:
         from_secret: github_token
     volumes:
@@ -49,9 +58,7 @@ steps:
     depends_on:
       - clone
     commands:
-      - |
-        mise use kustomize@5.6.0
-        eval "$(mise activate bash --shims)"
+      - eval "$(mise activate bash --shims)"
       - kustomize build katalog/cluster-autoscaler/base > cluster-autoscaler-base.yml
       - kustomize build katalog/cluster-autoscaler/v1.29.x > cluster-autoscaler-v1.29.yml
       - kustomize build katalog/cluster-autoscaler/v1.30.x > cluster-autoscaler-v1.30.yml
@@ -61,12 +68,27 @@ steps:
       - kustomize build katalog/load-balancer-controller > load-balancer-controller.yml
       - kustomize build katalog/node-termination-handler > node-termination-handler.yml
 
+  - name: lint
+    image: quay.io/sighup/mise:v2026.6.14
+    pull: always
+    environment:
+      MISE_DATA_DIR: /mise-data
+      GITHUB_TOKEN:
+        from_secret: github_token
+    volumes:
+      - name: mise-cache
+        path: /mise-data
+    depends_on:
+      - render
+    commands:
+      - mise run lint
+
   - &check-deprecated-apis
     name: check-deprecated-apis
     image: us-docker.pkg.dev/fairwinds-ops/oss/pluto:v5
     pull: always
     depends_on:
-      - render
+      - lint
     commands:
       # we use --ignore-deprecations because we don't want the CI to fail when the API has not been removed yet.
       - /pluto detect $${KUBERNETES_MANIFESTS} --ignore-deprecations --target-versions=k8s=v1.33.0
@@ -113,12 +135,12 @@ name: release
 kind: pipeline
 type: docker
 node:
-   performance: low
+  performance: low
 clone:
   depth: 1
 
 depends_on:
-  - linting
+  - validate
 
 platform:
   os: linux
@@ -133,7 +155,7 @@ steps:
   - name: prepare-tar-gz
     image: alpine:latest
     pull: always
-    depends_on: [clone]
+    depends_on: [ clone ]
     commands:
       - tar -zcvf kubernetes-fury-aws-${DRONE_TAG}.tar.gz katalog/ LICENSE README.md
     when:
@@ -144,7 +166,7 @@ steps:
   - name: prepare-release-notes
     image: quay.io/sighup/fury-release-notes-plugin:3.7_2.8.4
     pull: always
-    depends_on: [clone]
+    depends_on: [ clone ]
     settings:
       release_notes_file_path: release-notes.md
     when:

--- a/.kube-linter.yaml
+++ b/.kube-linter.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+checks:
+  doNotAutoAddDefaults: false
+  include:
+    - exposed-services
+    - use-namespace
+  exclude:
+    - job-ttl-seconds-after-finished
+    - no-read-only-root-fs
+    - pdb-unhealthy-pod-eviction-policy
+    - privilege-escalation-container
+    - privileged-container
+    - run-as-non-root
+    - unset-cpu-requirements
+    - unset-memory-requirements

--- a/katalog/load-balancer-controller/kustomization.yaml
+++ b/katalog/load-balancer-controller/kustomization.yaml
@@ -15,3 +15,15 @@ images:
   - name: public.ecr.aws/eks/aws-load-balancer-controller # public.ecr.aws/eks/aws-load-balancer-controller:v2.4.7
     newName: registry.sighup.io/fury/amazon/aws-alb-ingress-controller
     newTag: v2.13.4
+
+patches:
+  - target:
+      kind: Deployment
+      name: aws-load-balancer-controller
+    patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/ports/-
+        value:
+          containerPort: 61779
+          name: healthz
+          protocol: TCP

--- a/katalog/tests/kustomization.yaml
+++ b/katalog/tests/kustomization.yaml
@@ -1,0 +1,20 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kube-system
+resources:
+  - ../cluster-autoscaler/v1.34.x
+  - ../load-balancer-controller
+  - ../node-termination-handler
+patches:
+  - target:
+      kind: DaemonSet
+      name: aws-node-termination-handler
+    patch: |-
+      - op: add
+        path: /metadata/annotations
+        value:
+          ignore-check.kube-linter.io/host-network: "required to access instance metadata"

--- a/mise.toml
+++ b/mise.toml
@@ -3,8 +3,9 @@
 # license that can be found in the LICENSE file.
 
 [tools]
-kustomize = "5.6.0"
 dyff = "1.9.0"
+kustomize = "5.6.0"
+kube-linter = "0.8.3"
 "ubi:google/addlicense" = "v1.1.1"
 
 # Development task definitions
@@ -14,6 +15,14 @@ run = '''
 echo "📄 Adding license headers..."
 addlicense -c "SIGHUP s.r.l" -y "2017-present" -v -l bsd .
 echo "✅ License headers added!"
+'''
+
+[tasks.check-license]
+description = "Check that all files have license headers"
+run = '''
+echo "🔍 Checking license headers..."
+addlicense -c "SIGHUP s.r.l" -y "2017-present" -v -l bsd --check .
+echo "✅ All files have license headers!"
 '''
 
 [tasks.validate-manifests]
@@ -31,11 +40,10 @@ kustomize build katalog/node-termination-handler > /dev/null && echo "  ✅ node
 echo "✅ All manifests validated!"
 '''
 
-[tasks.setup]
-description = "Complete development environment setup"
+[tasks.lint]
+description = "Lint all katalog manifests with kube-linter"
 run = '''
-echo "🚀 Setting up development environment..."
-mise run add-license
-mise run validate-manifests
-echo "✅ Development environment ready!"
+echo "🔍 Linting katalog/ with kube-linter..."
+kube-linter lint --config .kube-linter.yaml ./katalog/tests
+echo "✅ All manifests passed linting!"
 '''


### PR DESCRIPTION
### Summary 💡

Introduce manifest checks with [kube-linter](https://github.com/stackrox/kube-linter).

### Description 📝

This new tool, when it detects a folder containing a kustomization file automatically processes it and scans the output.
I added the new step to the CI.

### Breaking Changes 💔

Not detected.

### Tests performed 🧪

- CI: https://ci.sighup.io/sighupio/module-aws/290
- I tested that adding a forbidden lint like an image with latest tag then the task fails

### Future work 🔧

Not planned.

### Self-assessment checklist 🏁

- [x] My PR has a clear scope and does not mix together several unrelated changes
- [ ] ~~I've updated the `docs/releases/unreleased.md` file (or equivalent)~~
- [x] I've tested the proposed changes and wrote the tests performed in the section above
- [x] My branch is up-to-date with the target branch and there are no conflicts
- [x] I've considered all the different cluster kinds (KFDDistribution, OnPremises, EKSCluster, Immutable) that may be affected by this change
- [x] CI is green